### PR TITLE
Have NuGet install newest NHibernate version when installing FLuentNHibernate in an empty project

### DIFF
--- a/src/FluentNHibernate.nuspec
+++ b/src/FluentNHibernate.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>http://github.com/jagregory/fluent-nhibernate/raw/master/LICENSE.txt</licenseUrl>
     <projectUrl>http://fluentnhibernate.org</projectUrl>
   	<dependencies>
-  		<dependency id="NHibernate" version="4.0" />
+  		<dependency id="NHibernate" version="4.*" />
   	</dependencies>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Fluent, XML-less, compile safe, automated, convention-based mappings for NHibernate.</description>


### PR DESCRIPTION
Changing the NHibernate dependency to be any 4.X, with Nuget trying to install always the latest NHibernate version.
I've clarified this behavior in [my comment here](https://github.com/jagregory/fluent-nhibernate/issues/365#issuecomment-330136149).

I'd like to put the change up for discusson. It changes the behavior of what dependency-version nuget installs, but I guess it doesn't make BindingRedirects unnecessary.