### PR TITLE
Target netstandard2.0 and NH 5.1.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -100,6 +100,20 @@ Task("Copy-Files")
             parameters.Configuration, 
             msBuildSettings
         );
+        PublishProjects(
+            SrcProjects, "netstandard2.0",
+            parameters.Paths.Directories.ArtifactsBinNetStandard20.FullPath, 
+            parameters.Version.DotNetAsterix, 
+            parameters.Configuration, 
+            msBuildSettings
+        );
+        PublishProjects(
+            SrcProjects, "netcoreapp2",
+            parameters.Paths.Directories.ArtifactsBinNetCoreApp2.FullPath, 
+            parameters.Version.DotNetAsterix, 
+            parameters.Configuration, 
+            msBuildSettings
+        );
         
         CopyFileToDirectory("./LICENSE", parameters.Paths.Directories.ArtifactsBinFullFx);            
     });
@@ -111,7 +125,7 @@ Task("Zip-Files")
         Zip(parameters.Paths.Directories.ArtifactsBinFullFx, parameters.Paths.Files.ZipArtifactPathDesktop, 
             GetFiles($"{parameters.Paths.Directories.ArtifactsBinFullFx.FullPath}/**/*"));
     });
-        
+  
 Task("Create-NuGet-Packages")
     .IsDependentOn("Copy-Files")
     .Does(() =>
@@ -120,7 +134,7 @@ Task("Create-NuGet-Packages")
             SrcProjects, 
             parameters.Paths.Directories.NuspecRoot.FullPath, 
             parameters.Paths.Directories.NugetRoot.FullPath, 
-            parameters.Paths.Directories.ArtifactsBinFullFx.FullPath, 
+            parameters.Paths.Directories.ArtifactsBin.FullPath, 
             parameters.Version.SemVersion);
     });
 

--- a/build.cake
+++ b/build.cake
@@ -186,7 +186,7 @@ Task("Update-AppVeyor-BuildNumber")
     .WithCriteria(() => parameters.IsRunningOnAppVeyor)
     .Does(() =>
     {
-        AppVeyor.UpdateBuildVersion(parameters.Version.SemVersion);
+        // AppVeyor.UpdateBuildVersion(parameters.Version.SemVersion);
     })
     .ReportError(exception =>
     {

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #addin "Cake.FileHelpers"
-#tool "nuget:?package=NUnit.ConsoleRunner&version=3.7.0"
+#tool "nuget:?package=NUnit.ConsoleRunner&version=3.8.0"
 #tool "nuget:?package=Machine.Specifications.Runner.Console&version=0.9.3"
 #tool "nuget:?package=GitReleaseManager&version=0.5.0"
 #tool "nuget:?package=GitVersion.CommandLine&version=3.6.2"
@@ -41,7 +41,7 @@ Teardown((context) =>
 });
 
 Task("Clean")
-	.Does(() =>
+  .Does(() =>
     {
         CleanDirectories(parameters.Paths.Directories.ToClean);        
         CleanProjects("src", SrcProjects);
@@ -51,7 +51,7 @@ Task("Clean")
         EnsureDirectoryExists(parameters.Paths.Directories.ArtifactsBinFullFx);
         EnsureDirectoryExists(parameters.Paths.Directories.TestResults);
         EnsureDirectoryExists(parameters.Paths.Directories.NugetRoot);
-	});
+  });
 
 Task("Restore")
     .IsDependentOn("Clean")
@@ -75,19 +75,34 @@ Task("Build")
 Task("Test")
     .IsDependentOn("Build")
     .Does(() =>
-    {          
-        var runtime = "net461";
-        var testAssemblies = $"./src/**/bin/{parameters.Configuration}/{runtime}/*.Testing.dll";  
-        NUnit3(testAssemblies, new NUnit3Settings {
-            NoResults = true
-        });
+    {    
+        var frameworks = new [] { "net461"};
+        foreach (var framework in frameworks)
+        {
+            var testAssemblies = $"./src/**/bin/{parameters.Configuration}/{framework}/*.Testing.dll";  
+            NUnit3(testAssemblies, new NUnit3Settings {
+              NoResults = true
+            });
 
-        testAssemblies = $"./src/**/bin/{parameters.Configuration}/{runtime}/*.Specs.dll";  
-        MSpec(testAssemblies, new MSpecSettings {
-            Silent = true
-        });
+            testAssemblies = $"./src/**/bin/{parameters.Configuration}/{framework}/*.Specs.dll";  
+            MSpec(testAssemblies, new MSpecSettings {
+              Silent = true
+            });
+        }   
+        /*
+        foreach(var project in TestProjects) 
+        {
+          var projectPath = File($"./src/{project}/{project}.csproj");
+          DotNetCoreTest(projectPath, new DotNetCoreTestSettings
+          {
+            Framework = "netcoreapp2.0",
+            NoBuild = true,
+            NoRestore = true,
+            Configuration = parameters.Configuration
+          });          
+        }
+        */
     });
-
 
 Task("Copy-Files")
     .IsDependentOn("Test")
@@ -263,7 +278,7 @@ private void BuildProjects(
     foreach(var project in projectNames)
     {
         var projectPath = File($"./{projectKind}/{project}/{project}.csproj");
-        DotNetCoreBuild(projectPath, new DotNetCoreBuildSettings()
+        DotNetCoreBuild(projectPath.ToString(), new DotNetCoreBuildSettings
         {
             Configuration = configuration,
             MSBuildSettings = msBuildSettings

--- a/build.cake
+++ b/build.cake
@@ -89,7 +89,7 @@ Task("Test")
               Silent = true
             });
         }   
-        /*
+        /* Tests not working in netcoreapp2.0
         foreach(var project in TestProjects) 
         {
           var projectPath = File($"./src/{project}/{project}.csproj");
@@ -123,7 +123,7 @@ Task("Copy-Files")
             msBuildSettings
         );
         PublishProjects(
-            SrcProjects, "netcoreapp2",
+            SrcProjects, "netcoreapp2.0",
             parameters.Paths.Directories.ArtifactsBinNetCoreApp2.FullPath, 
             parameters.Version.DotNetAsterix, 
             parameters.Configuration, 

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -24,6 +24,8 @@ public class BuildPaths
         var artifactsDir = (DirectoryPath)(context.Directory("./artifacts") + context.Directory("v" + semVersion));
         var artifactsBinDir = artifactsDir.Combine("bin");
         var artifactsBinFullFx = artifactsBinDir.Combine("net461");        
+        var artifactsBinNetStandard20 = artifactsBinDir.Combine("netstandard2.0");        
+        var artifactsBinNetCoreapp2 = artifactsBinDir.Combine("netcoreapp2");        
         var testResultsDir = artifactsDir.Combine("test-results");
         var nuspecRoot = (DirectoryPath)"nuspec";
         var nugetRoot = artifactsDir.Combine("nuget");
@@ -37,7 +39,9 @@ public class BuildPaths
             nuspecRoot,
             nugetRoot,
             artifactsBinDir,
-            artifactsBinFullFx);
+            artifactsBinFullFx,
+            artifactsBinNetStandard20,
+            artifactsBinNetCoreapp2);
 
         // Files
         var buildFiles = new BuildFiles(
@@ -72,6 +76,8 @@ public class BuildDirectories
     public DirectoryPath NugetRoot { get; private set; }
     public DirectoryPath ArtifactsBin { get; private set; }
     public DirectoryPath ArtifactsBinFullFx { get; private set; }    
+    public DirectoryPath ArtifactsBinNetStandard20 { get; private set; }    
+    public DirectoryPath ArtifactsBinNetCoreApp2 { get; private set; }    
     public ICollection<DirectoryPath> ToClean { get; private set; }
 
     public BuildDirectories(        
@@ -80,7 +86,10 @@ public class BuildDirectories
         DirectoryPath nuspecRoot,
         DirectoryPath nugetRoot,
         DirectoryPath artifactsBinDir,
-        DirectoryPath artifactsBinFullFx)
+        DirectoryPath artifactsBinFullFx,
+        DirectoryPath artifactsBinNetStandard20,
+        DirectoryPath artifactsBinNetCoreapp2
+        )
     {
         Artifacts = artifactsDir;
         TestResults = testResultsDir;
@@ -88,6 +97,8 @@ public class BuildDirectories
         NugetRoot = nugetRoot;
         ArtifactsBin = artifactsBinDir;
         ArtifactsBinFullFx = artifactsBinFullFx;        
+        ArtifactsBinNetStandard20 = artifactsBinNetStandard20;
+        ArtifactsBinNetCoreApp2 = artifactsBinNetCoreapp2;
         ToClean = new[] {
             Artifacts,
             TestResults,

--- a/build/paths.cake
+++ b/build/paths.cake
@@ -25,7 +25,7 @@ public class BuildPaths
         var artifactsBinDir = artifactsDir.Combine("bin");
         var artifactsBinFullFx = artifactsBinDir.Combine("net461");        
         var artifactsBinNetStandard20 = artifactsBinDir.Combine("netstandard2.0");        
-        var artifactsBinNetCoreapp2 = artifactsBinDir.Combine("netcoreapp2");        
+        var artifactsBinNetCoreapp2 = artifactsBinDir.Combine("netcoreapp2.0");        
         var testResultsDir = artifactsDir.Combine("test-results");
         var nuspecRoot = (DirectoryPath)"nuspec";
         var nugetRoot = artifactsDir.Combine("nuget");

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "src" ],
     "sdk": {
-        "version": "2.0.0"
+        "version": "2.1.4"
     }
 }

--- a/nuspec/FluentNHibernate.nuspec
+++ b/nuspec/FluentNHibernate.nuspec
@@ -19,7 +19,11 @@
   	</dependencies>
   </metadata>
     <files>
-      <file src="FluentNHibernate.dll" target="lib/net461" />    
-      <file src="FluentNHibernate.xml" target="lib/net461" />
+      <file src="net461/FluentNHibernate.dll" target="lib/net461" />    
+      <file src="net461/FluentNHibernate.xml" target="lib/net461" />
+      <file src="netstandard2.0/FluentNHibernate.dll" target="lib/netstandard2.0" />    
+      <file src="netstandard2.0/FluentNHibernate.xml" target="lib/netstandard2.0" />
+      <file src="netcoreapp2/FluentNHibernate.dll" target="lib/netcoreapp2" />    
+      <file src="netcoreapp2/FluentNHibernate.xml" target="lib/netcoreapp2" />
   </files>
 </package>

--- a/nuspec/FluentNHibernate.nuspec
+++ b/nuspec/FluentNHibernate.nuspec
@@ -15,7 +15,7 @@
     <tags>ORM DAL NHibernate DataBase ADO.Net Mappings Conventions</tags>
     <copyright>Copyright (c) James Gregory and contributors (Paul Batum, Hudson Akridge, Gleb Chermennov, Jorge Rodríguez Galán).</copyright>
     <dependencies>
-  		<dependency id="NHibernate" version="5.0.3" />      
+  		<dependency id="NHibernate" version="5.1.0" />      
   	</dependencies>
   </metadata>
     <files>

--- a/nuspec/FluentNHibernate.nuspec
+++ b/nuspec/FluentNHibernate.nuspec
@@ -23,7 +23,7 @@
       <file src="net461/FluentNHibernate.xml" target="lib/net461" />
       <file src="netstandard2.0/FluentNHibernate.dll" target="lib/netstandard2.0" />    
       <file src="netstandard2.0/FluentNHibernate.xml" target="lib/netstandard2.0" />
-      <file src="netcoreapp2/FluentNHibernate.dll" target="lib/netcoreapp2" />    
-      <file src="netcoreapp2/FluentNHibernate.xml" target="lib/netcoreapp2" />
+      <file src="netcoreapp2.0/FluentNHibernate.dll" target="lib/netcoreapp2.0" />    
+      <file src="netcoreapp2.0/FluentNHibernate.xml" target="lib/netcoreapp2.0" />
   </files>
 </package>

--- a/nuspec/FluentNHibernate.symbols.nuspec
+++ b/nuspec/FluentNHibernate.symbols.nuspec
@@ -19,8 +19,14 @@
   	</dependencies>
   </metadata>
   <files>
-    <file src="FluentNHibernate.dll" target="lib/net461" />
-    <file src="FluentNHibernate.pdb" target="lib/net461" />
-    <file src="FluentNHibernate.xml" target="lib/net461" />
+      <file src="net461/FluentNHibernate.dll" target="lib/net461" />    
+      <file src="net461/FluentNHibernate.xml" target="lib/net461" />
+      <file src="net461/FluentNHibernate.pdb" target="lib/net461" />
+      <file src="netstandard2.0/FluentNHibernate.dll" target="lib/netstandard2.0" />    
+      <file src="netstandard2.0/FluentNHibernate.xml" target="lib/netstandard2.0" />
+      <file src="netstandard2.0/FluentNHibernate.pdb" target="lib/netstandard2.0" />
+      <file src="netcoreapp2/FluentNHibernate.dll" target="lib/netcoreapp2" />    
+      <file src="netcoreapp2/FluentNHibernate.xml" target="lib/netcoreapp2" />
+      <file src="netcoreapp2/FluentNHibernate.pdb" target="lib/netcoreapp2" />
   </files>
 </package>

--- a/nuspec/FluentNHibernate.symbols.nuspec
+++ b/nuspec/FluentNHibernate.symbols.nuspec
@@ -15,7 +15,7 @@
     <tags>ORM DAL NHibernate DataBase ADO.Net Mappings Conventions</tags>
     <copyright>Copyright (c) James Gregory and contributors (Paul Batum, Hudson Akridge, Gleb Chermennov, Jorge Rodríguez Galán).</copyright>
     <dependencies>
-  		<dependency id="NHibernate" version="5.0.3" />
+  		<dependency id="NHibernate" version="5.1.0" />
   	</dependencies>
   </metadata>
   <files>

--- a/nuspec/FluentNHibernate.symbols.nuspec
+++ b/nuspec/FluentNHibernate.symbols.nuspec
@@ -25,8 +25,8 @@
       <file src="netstandard2.0/FluentNHibernate.dll" target="lib/netstandard2.0" />    
       <file src="netstandard2.0/FluentNHibernate.xml" target="lib/netstandard2.0" />
       <file src="netstandard2.0/FluentNHibernate.pdb" target="lib/netstandard2.0" />
-      <file src="netcoreapp2/FluentNHibernate.dll" target="lib/netcoreapp2" />    
-      <file src="netcoreapp2/FluentNHibernate.xml" target="lib/netcoreapp2" />
-      <file src="netcoreapp2/FluentNHibernate.pdb" target="lib/netcoreapp2" />
+      <file src="netcoreapp2.0/FluentNHibernate.dll" target="lib/netcoreapp2.0" />    
+      <file src="netcoreapp2.0/FluentNHibernate.xml" target="lib/netcoreapp2.0" />
+      <file src="netcoreapp2.0/FluentNHibernate.pdb" target="lib/netcoreapp2.0" />
   </files>
 </package>

--- a/src/Examples.FirstAutomappedProject/Examples.FirstAutomappedProject.csproj
+++ b/src/Examples.FirstAutomappedProject/Examples.FirstAutomappedProject.csproj
@@ -15,7 +15,7 @@
   
   <ItemGroup>    
     <PackageReference Include="EntityFramework" Version="6.2.0" />    
-    <PackageReference Include="NHibernate" Version="5.0.3" />    
+    <PackageReference Include="NHibernate" Version="5.1.0" />    
     <PackageReference Include="System.Data.SQLite" Version="1.0.106.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.106.0" />
     <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106.0" />

--- a/src/Examples.FirstProject/Examples.FirstProject.csproj
+++ b/src/Examples.FirstProject/Examples.FirstProject.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>    
     <PackageReference Include="EntityFramework" Version="6.2.0" />    
-    <PackageReference Include="NHibernate" Version="5.0.3" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.106.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.106.0" />
     <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106.0" />

--- a/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
+++ b/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>    
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>    
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
   </PropertyGroup>
@@ -19,11 +19,7 @@
     <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>
 

--- a/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
+++ b/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>    
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>    
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
   </PropertyGroup>
@@ -15,14 +15,16 @@
     <ProjectReference Include="..\FluentNHibernate\FluentNHibernate.csproj" />
   </ItemGroup>
 
-  <ItemGroup>    
-    <PackageReference Include="NHibernate" Version="5.1.0" />    
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Transactions" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2'">
+    <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
+++ b/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>    
-    <PackageReference Include="NHibernate" Version="5.0.3" />    
+    <PackageReference Include="NHibernate" Version="5.1.0" />    
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
+++ b/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>    
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>    
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp2.0'">Full</DebugType>
@@ -29,15 +29,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="Machine.Specifications.Runner.Console" Version="0.9.3" />
-    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.5.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Machine.Specifications" Version="0.12.0" />

--- a/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
+++ b/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>    
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>    
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp2.0'">Full</DebugType>
   </PropertyGroup>  
 
   <Import Project="$(MSBuildThisFileDirectory)..\Shared.msbuild" />
@@ -14,23 +14,38 @@
     <ProjectReference Include="..\FluentNHibernate\FluentNHibernate.csproj" />
   </ItemGroup>
 
-  <ItemGroup>    
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />    
-    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="Machine.Specifications.Runner.Console" Version="0.9.3" />
-    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.5.2" />
-    <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />
-    <PackageReference Include="NHibernate" Version="5.1.0" />    
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xml.Serialization" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
+    <PackageReference Include="Machine.Specifications.Runner.Console" Version="0.9.3" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.5.2" />
+    <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
+    <PackageReference Include="Machine.Specifications.Runner.Console" Version="0.9.3" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.5.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2'">
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
+    <PackageReference Include="Machine.Specifications.Runner.Console" Version="0.9.3" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.5.2" />
+  </ItemGroup>
+
+
   
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
+++ b/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Machine.Specifications.Runner.Console" Version="0.9.3" />
     <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.5.2" />
     <PackageReference Include="Mono.Cecil" Version="0.9.6.1" />
-    <PackageReference Include="NHibernate" Version="5.0.3" />    
+    <PackageReference Include="NHibernate" Version="5.1.0" />    
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/src/FluentNHibernate.Testing/AutoMapping/TestFixtures.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/TestFixtures.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System;
 using System.Data;
 using System.Drawing;
-using System.IO;
 using FluentNHibernate.Automapping.TestFixtures.ComponentTypes;
 using FluentNHibernate.Automapping.TestFixtures.CustomCompositeTypes;
 using FluentNHibernate.Automapping.TestFixtures.CustomTypes;

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
@@ -22,18 +22,6 @@
     <ProjectReference Include="..\FluentNHibernate\FluentNHibernate.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.3.0" />    
-    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
-    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
-    <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview1-26216-02" />
-  </ItemGroup>
- 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -44,23 +32,24 @@
     <PackageReference Include="FakeItEasy" Version="4.3.0" />
     <PackageReference Include="Machine.Specifications" Version="0.12.0" />
     <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
 
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="FakeItEasy" Version="4.3.0" />
     <PackageReference Include="Machine.Specifications" Version="0.12.0" />
     <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview1-26216-02" />
   </ItemGroup>
 
 

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="4.3.0" />    
     <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="NHibernate" Version="5.0.3" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.106" />

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
@@ -31,6 +31,7 @@
     <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
     <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
+    <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview1-26216-02" />
   </ItemGroup>
  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -40,7 +41,28 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Serialization" />
+    <PackageReference Include="FakeItEasy" Version="4.3.0" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
+    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
+    <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
+
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="FakeItEasy" Version="4.3.0" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
+    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
+    <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <OutputType>Library</OutputType>
@@ -32,7 +32,7 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="NHibernate" Version="5.1.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
   </ItemGroup>

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <OutputType>Library</OutputType>
@@ -32,7 +32,12 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
   </ItemGroup>
 
- 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2'">
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
+  </ItemGroup>
+
+
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -21,7 +21,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\Shared.msbuild" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="NHibernate" Version="5.0.3" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
     <Reference Include="System.configuration" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <OutputType>Library</OutputType>
@@ -13,22 +13,26 @@
     <Description>FluentNHibernate</Description>
   </PropertyGroup>
   
-  <Import Project="$(MSBuildThisFileDirectory)..\Shared.msbuild" />
   
   <PropertyGroup>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="NHibernate" Version="5.0.3" />    
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+
+  <Import Project="$(MSBuildThisFileDirectory)..\Shared.msbuild" />
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="NHibernate" Version="5.0.3" />
     <Reference Include="System.configuration" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
-  
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
+  </ItemGroup>
+
+ 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
@@ -37,4 +41,5 @@
       <Link>FluentKey.snk</Link>
     </None>
   </ItemGroup>
+
 </Project>

--- a/src/Shared.msbuild
+++ b/src/Shared.msbuild
@@ -23,4 +23,18 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  
 </Project>


### PR DESCRIPTION
NHibernate 5.1 was released in the last 24hours, with support for netstandard2.0. This PR attempts to add  that support.  To get it to build I had to delete global.json so it would use the lastest non preview sdk version  (2.1.101) - I didn't commit that. 