### PR TITLE
Fix AssemblyVersion calculation by GitVersion during Release build

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,3 @@
-assembly-versioning-scheme: None
 branches:
   master:
     mode: ContinuousDelivery


### PR DESCRIPTION
Fix for issue #392 

I simulated release build locally. Nuget package result:
![image](https://user-images.githubusercontent.com/18299360/38209168-c5f3f6a8-36b3-11e8-84d7-93d30ba4e585.png)