### PR TITLE
feat(netcore2): add netcore2 with netstandard serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,30 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/3uk49dtw8u4hdt7w/branch/master?svg=true)](https://ci.appveyor.com/project/jrogalan/fluent-nhibernate/branch/master)
 [![NuGet](https://img.shields.io/nuget/v/FluentNHibernate.svg)](https://www.nuget.org/packages/FluentNHibernate)
 
+## What is FluentNHibernate?
 Fluent, XML-less, compile safe, automated, convention-based mappings for NHibernate. *Get your fluent on.*
 
+## Where can I get it?
 
-Getting started
----------------------------------------------
+Install using the [FluentNHibernate NuGet package](https://www.nuget.org/packages/FluentNHibernate):
+
+```
+dotnet add package FluentNHibernate
+```
+
+## How do I use it?
 
 * Read the [introduction](https://github.com/FluentNHibernate/fluent-nhibernate/wiki/Getting-started).
 * Get latest version from NuGet
-    - [.NET 4.6.1 with NHibernate 5.x](https://www.nuget.org/packages/FluentNHibernate)
+    - [.NETCore2.0, NETStandard2.0 or NET 4.6.1 with NHibernate 5.x](https://www.nuget.org/packages/FluentNHibernate)
     - [.NET 4.0 with NHibernate 4.x](https://www.nuget.org/packages/FluentNHibernate/2.0.3)
     - [.NET 3.5 with NHibernate 3 if you like it vintage](https://www.nuget.org/packages/FluentNHibernate.Net35)
 
 * Create your [first project](https://github.com/FluentNHibernate/fluent-nhibernate/wiki/Getting-started#wiki-yourfirstproject).
 
-Further reading
----------------------------------------------
+## Further reading
 
 Once you've followed the above, you can compare our [auto mapping](https://github.com/FluentNHibernate/fluent-nhibernate/wiki/Auto-mapping) to our [fluent interface](https://github.com/FluentNHibernate/fluent-nhibernate/wiki/Fluent-mapping) to see which suits your application, read through our [API documentation](https://github.com/FluentNHibernate/fluent-nhibernate/wiki/Fluent-configuration), or just see what's available for reading in our [wiki](https://github.com/FluentNHibernate/fluent-nhibernate/wiki).
-
-
-Building
----------------------------------------------
-
-Follow the instructions from the [wiki page](https://github.com/FluentNHibernate/fluent-nhibernate/wiki/Building) to build the project.
 
 Contributors
 ---------------------------------------------

--- a/build.cake
+++ b/build.cake
@@ -75,33 +75,41 @@ Task("Build")
 Task("Test")
     .IsDependentOn("Build")
     .Does(() =>
-    {    
-        var frameworks = new [] { "net461"};
-        foreach (var framework in frameworks)
-        {
-            var testAssemblies = $"./src/**/bin/{parameters.Configuration}/{framework}/*.Testing.dll";  
-            NUnit3(testAssemblies, new NUnit3Settings {
-              NoResults = true
-            });
+    {       
+        var unitProjects = GetFiles("./src/**/*.Testing.csproj");
+        var specProjects = GetFiles("./src/**/*.Specs.csproj");
+        var testProjects = unitProjects.Union(specProjects).ToArray();
 
-            testAssemblies = $"./src/**/bin/{parameters.Configuration}/{framework}/*.Specs.dll";  
-            MSpec(testAssemblies, new MSpecSettings {
-              Silent = true
-            });
-        }   
-        /* Tests not working in netcoreapp2.0
-        foreach(var project in TestProjects) 
-        {
-          var projectPath = File($"./src/{project}/{project}.csproj");
-          DotNetCoreTest(projectPath, new DotNetCoreTestSettings
-          {
-            Framework = "netcoreapp2.0",
-            NoBuild = true,
-            NoRestore = true,
-            Configuration = parameters.Configuration
-          });          
+        // foreach (var framework in frameworks)
+        // {
+        //     var testAssemblies = $"./src/**/bin/{parameters.Configuration}/{framework}/*.Testing.dll";  
+        //     NUnit3(testAssemblies, new NUnit3Settings {
+        //       NoResults = true
+        //     });
+
+        //     testAssemblies = $"./src/**/bin/{parameters.Configuration}/{framework}/*.Specs.dll";  
+        //     MSpec(testAssemblies, new MSpecSettings {
+        //       Silent = true
+        //     });
+        // }           
+        foreach(var project in testProjects) 
+        {                      
+            DotNetCoreTest(project.ToString(), new DotNetCoreTestSettings
+            {
+                Framework = "net461",
+                NoBuild = true,
+                NoRestore = true,
+                Configuration = parameters.Configuration
+            });          
+
+            DotNetCoreTest(project.ToString(), new DotNetCoreTestSettings
+            {
+                Framework = "netcoreapp2.0",
+                NoBuild = true,
+                NoRestore = true,
+                Configuration = parameters.Configuration
+            });          
         }
-        */
     });
 
 Task("Copy-Files")

--- a/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
+++ b/src/FluentNHibernate.Specs.ExternalFixtures/FluentNHibernate.Specs.ExternalFixtures.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>    
     <NoWarn>1591</NoWarn>
-    <PlatformTarget>AnyCpu</PlatformTarget>
   </PropertyGroup>
 
   <Import Project="..\Shared.msbuild" />
@@ -15,12 +14,8 @@
     <ProjectReference Include="..\FluentNHibernate\FluentNHibernate.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup>
     <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-  </ItemGroup>
-
+  
 </Project>

--- a/src/FluentNHibernate.Specs/Automapping/AutoPersistenceModelSpecs.cs
+++ b/src/FluentNHibernate.Specs/Automapping/AutoPersistenceModelSpecs.cs
@@ -5,7 +5,6 @@ using System.Xml;
 using FluentNHibernate.Automapping;
 using FluentNHibernate.Cfg;
 using FluentNHibernate.Cfg.Db;
-using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.Specs.Automapping.Fixtures;
 using FluentNHibernate.Specs.ExternalFixtures;
@@ -48,8 +47,10 @@ namespace FluentNHibernate.Specs.Automapping
     public class when_the_automapper_is_ran_to_completion
     {
         Establish context = () =>
+
             setup = Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(x => x.AutoMappings.Add(AutoMap.Source(new StubTypeSource(typeof(Entity)))));
 
         Because of = () =>
@@ -60,6 +61,18 @@ namespace FluentNHibernate.Specs.Automapping
 
         static FluentConfiguration setup;
         static Exception ex;
+
+        private static IPersistenceConfigurer CreateStandardInMemoryConfiguration()
+        {
+#if NETFX
+            var configuration = SQLiteConfiguration.Standard.InMemory();
+#endif
+
+#if NETCORE
+            var configuration = MsSqliteConfiguration.Standard.InMemory();
+#endif
+            return configuration;
+        }
     }
 
     public class when_the_automapper_is_told_to_map_an_inheritance_hierarchy

--- a/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
+++ b/src/FluentNHibernate.Specs/FluentNHibernate.Specs.csproj
@@ -3,16 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <NoWarn>1591</NoWarn>
-    <PlatformTarget>AnyCpu</PlatformTarget>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp2.0'">Full</DebugType>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\Shared.msbuild" />
-
-  <ItemGroup>
-    <ProjectReference Include="..\FluentNHibernate.Specs.ExternalFixtures\FluentNHibernate.Specs.ExternalFixtures.csproj" />
-    <ProjectReference Include="..\FluentNHibernate\FluentNHibernate.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\FluentNHibernate.Specs.ExternalFixtures\FluentNHibernate.Specs.ExternalFixtures.csproj" />

--- a/src/FluentNHibernate.Testing/App.config
+++ b/src/FluentNHibernate.Testing/App.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <startup>
     <supportedRuntime version="v2.0.50727"></supportedRuntime>
@@ -12,22 +10,9 @@
   </appSettings>
   <connectionStrings>
     <add name="main" connectionString="connection string" />
-  </connectionStrings>
-  <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
-      <parameters>
-        <parameter value="v13.0" />
-      </parameters>
-    </defaultConnectionFactory>
-    <providers>
-      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
-    </providers>
-  </entityFramework>
+  </connectionStrings> 
   <system.data>
     <DbProviderFactories>
-      <remove invariant="System.Data.SQLite.EF6" />
-      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
       <remove invariant="System.Data.SQLite" />
       <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
     </DbProviderFactories>

--- a/src/FluentNHibernate.Testing/AutoMapping/BaseAutoMapFixture.cs
+++ b/src/FluentNHibernate.Testing/AutoMapping/BaseAutoMapFixture.cs
@@ -1,8 +1,8 @@
 using System;
 using FluentNHibernate.Automapping;
-using FluentNHibernate.Cfg.Db;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.Automapping
 {
@@ -16,8 +16,7 @@ namespace FluentNHibernate.Testing.Automapping
         {
             cfg = new Configuration();
 
-            SQLiteConfiguration.Standard
-                .InMemory()
+            CreateStandardInMemoryConfiguration()
                 .ConfigureProperties(cfg);
         }
 

--- a/src/FluentNHibernate.Testing/Cfg/Db/ConnectionStringBuilderTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/ConnectionStringBuilderTester.cs
@@ -22,19 +22,23 @@ namespace FluentNHibernate.Testing.Cfg.Db
             builder.ConnectionString.ShouldEqual("a string");
         }
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
             builder.FromAppSetting("connectionString");
             builder.ConnectionString.ShouldContain("a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
             builder.FromConnectionStringWithKey("main");
             builder.ConnectionString.ShouldContain("connection string");
         }
+#endif
 
         private class ConnectionStringBuilderDouble : ConnectionStringBuilder
         {

--- a/src/FluentNHibernate.Testing/Cfg/Db/DB2400ConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/DB2400ConfigurationTester.cs
@@ -39,6 +39,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
@@ -47,7 +48,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
@@ -56,6 +59,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/DB2ConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/DB2ConfigurationTester.cs
@@ -46,6 +46,7 @@ namespace FluentNHibernate.Testing.Cfg
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
@@ -54,7 +55,9 @@ namespace FluentNHibernate.Testing.Cfg
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
@@ -63,6 +66,7 @@ namespace FluentNHibernate.Testing.Cfg
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/IngresConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/IngresConfigurationTester.cs
@@ -40,7 +40,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .Is("value"))
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
-        
+
+
+#if NETFX
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
@@ -49,7 +51,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
@@ -58,6 +62,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/JetDriverConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/JetDriverConfigurationTester.cs
@@ -54,6 +54,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if !NETCORE
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
@@ -62,7 +63,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if !NETCORE
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
@@ -71,6 +74,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/MsSqlConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/MsSqlConfigurationTester.cs
@@ -87,6 +87,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
@@ -95,7 +96,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
@@ -104,6 +107,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/MySQLConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/MySQLConfigurationTester.cs
@@ -40,6 +40,7 @@ namespace FluentNHibernate.Testing.Cfg
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
@@ -48,7 +49,9 @@ namespace FluentNHibernate.Testing.Cfg
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
@@ -57,6 +60,7 @@ namespace FluentNHibernate.Testing.Cfg
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/OracleClientConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/OracleClientConfigurationTester.cs
@@ -97,7 +97,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties().ShouldContain("connection.connection_string",
                                               "User Id=test;Password=secret;Pooling=False;Statement Cache Size=50;Min Pool Size=10;Incr Pool Size=5;Decr Pool Size=2;Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=db-srv)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=mydatabase)))");
         }
-        
+
         [Test]
         public void ConnectionString_set_explicitly()
         {
@@ -107,6 +107,8 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if NETFX
+
         [Test]
         public void ConnectionString_set_fromAppSetting()
         {
@@ -115,7 +117,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionString_set_fromConnectionStrings()
         {
@@ -124,6 +128,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/OracleDataClientConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/OracleDataClientConfigurationTester.cs
@@ -110,6 +110,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if NETFX
         [Test]
         public void ConnectionString_set_fromAppSetting()
         {
@@ -118,7 +119,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionString_set_fromConnectionStrings()
         {
@@ -127,6 +130,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/OracleManagedDataClientConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/OracleManagedDataClientConfigurationTester.cs
@@ -110,6 +110,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
             .ToProperties().ShouldContain("connection.connection_string", "value");
       }
 
+#if NETFX
       [Test]
       public void ConnectionString_set_fromAppSetting()
       {
@@ -118,7 +119,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                .FromAppSetting("connectionString"))
             .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
       }
+#endif
 
+#if NETFX
       [Test]
       public void ConnectionString_set_fromConnectionStrings()
       {
@@ -127,6 +130,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                .FromConnectionStringWithKey("main"))
             .ToProperties().ShouldContain("connection.connection_string", "connection string");
       }
+#endif
 
       [Test]
       public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/PostgreSQLConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/PostgreSQLConfigurationTester.cs
@@ -57,6 +57,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties().ShouldContain("connection.connection_string", "value");
         }
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromAppSetting()
         {
@@ -65,7 +66,9 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromAppSetting("connectionString"))
                 .ToProperties().ShouldContain("connection.connection_string", "a-connection-string");
         }
+#endif
 
+#if NETFX
         [Test]
         public void ConnectionStringSetFromConnectionStrings()
         {
@@ -74,6 +77,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                     .FromConnectionStringWithKey("main"))
                 .ToProperties().ShouldContain("connection.connection_string", "connection string");
         }
+#endif
 
         [Test]
         public void ShouldBeAbleToSpecifyConnectionStringDirectly()

--- a/src/FluentNHibernate.Testing/Cfg/Db/SQLiteConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Cfg/Db/SQLiteConfigurationTester.cs
@@ -3,9 +3,11 @@ using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.Cfg.Db
 {
+
     [TestFixture]
     public class SQLiteConfigurationTester
     {
+#if NETFX
         [Test]
         public void should_set_up_default_query_substitutions()
         {
@@ -19,6 +21,7 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties()["connection.connection_string"].ShouldEqual("Data Source=:memory:;Version=3;New=True;");
         }
 
+
         [Test]
         public void using_file_should_set_up_expected_connection_string()
         {
@@ -26,11 +29,13 @@ namespace FluentNHibernate.Testing.Cfg.Db
                 .ToProperties()["connection.connection_string"].ShouldEqual("Data Source=foo;Version=3;New=True;");
         }
 
+
         [Test]
         public void using_file_with_password_shuold_set_up_expected_connection_string()
         {
             new SQLiteConfiguration().UsingFileWithPassword("foo", "bar")
                 .ToProperties()["connection.connection_string"].ShouldEqual("Data Source=foo;Version=3;New=True;Password=bar;");
         }
+#endif
     }
 }

--- a/src/FluentNHibernate.Testing/Cfg/ExceptionSerializationTests.cs
+++ b/src/FluentNHibernate.Testing/Cfg/ExceptionSerializationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using FluentNHibernate.Cfg;
+using FluentNHibernate.Utils;
 using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.Cfg
@@ -34,19 +35,20 @@ namespace FluentNHibernate.Testing.Cfg
         public void ShouldSerializeUnknownPropertyExceptionCorrectly()
         {
             var original = new UnknownPropertyException(typeof(string), "Property1");
-            var formatter = new BinaryFormatter();
+            UnknownPropertyException result;
 
             using (var stream = new MemoryStream())
             {
+                var formatter = new BinaryFormatter();
                 formatter.Serialize(stream, original);
                 stream.Position = 0;
 
-                var result = formatter.Deserialize(stream) as UnknownPropertyException;
-
-                original.Message.ShouldEqual(result.Message);
-                original.Property.ShouldEqual(result.Property);
-                original.Type.ShouldEqual(result.Type);
+                result = formatter.Deserialize(stream) as UnknownPropertyException;
             }
+
+            result.Message.ShouldEqual(original.Message);
+            result.Property.ShouldEqual(original.Property);
+            result.Type.ShouldEqual(original.Type);
         }
     }
 }

--- a/src/FluentNHibernate.Testing/Cfg/FluentConfigurationTests.cs
+++ b/src/FluentNHibernate.Testing/Cfg/FluentConfigurationTests.cs
@@ -11,12 +11,14 @@ using FluentNHibernate.Testing.Fixtures.MixedMappingsInSameLocation;
 using FluentNHibernate.Testing.Fixtures.MixedMappingsInSameLocation.Mappings;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.Cfg
 {
     [TestFixture]
     public class ValidFluentConfigurationTests
     {
+
         [Test]
         public void ExposeConfigurationPassesCfgInstanceIntoAction()
         {
@@ -43,7 +45,8 @@ namespace FluentNHibernate.Testing.Cfg
             var calls = new List<string>();
 
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .ExposeConfiguration(cfg => calls.Add("One"))
                 .ExposeConfiguration(cfg => calls.Add("Two"))
                 .BuildSessionFactory();
@@ -56,7 +59,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void DatabaseSetsPropertiesOnCfg()
         {
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard)
+                .Database(
+                    CreateStandardConfiguration())
                 .ExposeConfiguration(cfg =>
                 {
                     cfg.Properties.ContainsKey("connection.provider").ShouldBeTrue();
@@ -67,7 +71,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void ExposeConfigurationGetsConfigAfterMappingsHaveBeenApplied()
         {
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.FluentMappings.AddFromAssemblyOf<Record>())
                 .ExposeConfiguration(cfg =>
@@ -91,7 +96,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void MappingsCanBeMixedAndDontConflict()
         {
             var sessionFactory = Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                 {
                     m.FluentMappings.Add<FooMap>();
@@ -107,7 +113,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void ShouldGetASessionFactoryIfEverythingIsOK()
         {
             var sessionFactory = Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.FluentMappings.Add<BinaryRecordMap>())
                 .BuildSessionFactory();
@@ -119,8 +126,9 @@ namespace FluentNHibernate.Testing.Cfg
 		public void ShouldGetAConfigurationIfEverythingIsOK()
 		{
 			var configuration = Fluently.Configure()
-				.Database(SQLiteConfiguration.Standard.InMemory)
-				.Mappings(m =>
+				.Database(
+                    CreateStandardInMemoryConfiguration())
+                .Mappings(m =>
 					m.FluentMappings.Add<BinaryRecordMap>())
 				.BuildConfiguration();
 
@@ -147,11 +155,14 @@ namespace FluentNHibernate.Testing.Cfg
  			configuration.Properties["current_session_context_class"].ShouldEqual(typeof(NHibernate.Context.ThreadStaticSessionContext).AssemblyQualifiedName);
      	}
 
+
+
         [Test]
         public void ShouldSetConnectionIsolationLevel()
         {
             var configuration = Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.IsolationLevel(IsolationLevel.ReadUncommitted))
+                .Database(
+                    CreateStandardConfiguration(IsolationLevel.ReadUncommitted))
                 .BuildConfiguration();
 
             configuration.Properties["connection.isolation"].ShouldEqual("ReadUncommitted");
@@ -238,7 +249,8 @@ namespace FluentNHibernate.Testing.Cfg
         {
             var ex = Assert.Throws<FluentConfigurationException>(() =>
                 Fluently.Configure()
-                    .Database(SQLiteConfiguration.Standard)
+                    .Database(
+                        CreateStandardConfiguration())
                     .BuildSessionFactory());
 
             ex.PotentialReasons.Contains(ExceptionDatabaseMessage)
@@ -250,7 +262,8 @@ namespace FluentNHibernate.Testing.Cfg
         {
             var ex = Assert.Throws<FluentConfigurationException>(() =>
                 Fluently.Configure()
-                    .Database(SQLiteConfiguration.Standard)
+                    .Database(
+                        CreateStandardConfiguration())
                     .BuildSessionFactory());
 
             ex.PotentialReasons.ShouldContain(ExceptionMappingMessage);
@@ -261,7 +274,8 @@ namespace FluentNHibernate.Testing.Cfg
         {
             var ex = Assert.Throws<FluentConfigurationException>(() =>
                 Fluently.Configure()
-                    .Database(SQLiteConfiguration.Standard)
+                    .Database(
+                        CreateStandardConfiguration())
                     .Mappings(m =>
                         m.FluentMappings.AddFromAssemblyOf<Record>())
                     .BuildSessionFactory());
@@ -275,7 +289,8 @@ namespace FluentNHibernate.Testing.Cfg
         {
             var ex = Assert.Throws<FluentConfigurationException>(() =>
                 Fluently.Configure()
-                    .Database(SQLiteConfiguration.Standard)
+                    .Database(
+                        CreateStandardConfiguration())
                     .Mappings(m =>
                         m.FluentMappings.AddFromAssemblyOf<Record>())
                     .BuildSessionFactory());
@@ -306,7 +321,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void WritesFluentMappingsOut()
         {
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.FluentMappings
                         .Add<BinaryRecordMap>()
@@ -320,10 +336,11 @@ namespace FluentNHibernate.Testing.Cfg
         [Test]
         public void WritesFluentMappingsOutToTextWriter()
         {
-            var stringWriter = new StringWriter();            
+            var stringWriter = new StringWriter();
 
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.FluentMappings
                         .Add<BinaryRecordMap>()
@@ -338,7 +355,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void WritesFluentMappingsOutMergedWhenFlagSet()
         {
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.MergeMappings()
                      .FluentMappings
@@ -354,7 +372,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void WritesAutoMappingsOut()
         {
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.AutoMappings.Add(AutoMap.AssemblyOf<Person>()
                                         .Where(type => type.Namespace == "FluentNHibernate.Testing.Fixtures.Basic"))
@@ -369,7 +388,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void WritesAutoMappingsOutMergedWhenFlagSet()
         {
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.MergeMappings()
                      .AutoMappings.Add(AutoMap.AssemblyOf<Person>()
@@ -385,7 +405,8 @@ namespace FluentNHibernate.Testing.Cfg
         public void WritesBothOut()
         {
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory())
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                 {
                     m.FluentMappings
@@ -399,7 +420,7 @@ namespace FluentNHibernate.Testing.Cfg
                 .BuildSessionFactory();
 
             var files = Directory.GetFiles(ExportPath);
-            
+
             files.ShouldContain(HbmFor<BinaryRecord>);
             files.ShouldContain(HbmFor<Person>);
         }
@@ -409,7 +430,8 @@ namespace FluentNHibernate.Testing.Cfg
         {
             //Regression test for isue 131
             Fluently.Configure()
-                .Database(SQLiteConfiguration.Standard.InMemory)
+                .Database(
+                    CreateStandardInMemoryConfiguration())
                 .Mappings(m =>
                     m.FluentMappings
                         .Add<CachedRecordMap>()

--- a/src/FluentNHibernate.Testing/Cfg/MappingConfigurationTests.cs
+++ b/src/FluentNHibernate.Testing/Cfg/MappingConfigurationTests.cs
@@ -2,14 +2,13 @@ using System.Linq;
 using FakeItEasy;
 using FluentNHibernate.Automapping;
 using FluentNHibernate.Cfg;
-using FluentNHibernate.Cfg.Db;
 using FluentNHibernate.Conventions.Helpers;
 using FluentNHibernate.Diagnostics;
 using FluentNHibernate.Testing.DomainModel;
 using FluentNHibernate.Testing.Fixtures;
-using FluentNHibernate.Testing.Utils;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.Cfg
 {
@@ -26,8 +25,7 @@ namespace FluentNHibernate.Testing.Cfg
             logger = A.Fake<IDiagnosticLogger>();
             cfg = new Configuration();
 
-            SQLiteConfiguration.Standard
-                .InMemory()
+            CreateStandardInMemoryConfiguration()
                 .ConfigureProperties(cfg);
 
             mapping = new MappingConfiguration(logger);
@@ -175,11 +173,11 @@ namespace FluentNHibernate.Testing.Cfg
         public void MergeOutputShouldSetFlagOnFluentPersistenceModelsOnApply()
         {
             var model = new PersistenceModel();
-            
+
             mapping.UsePersistenceModel(model);
             mapping.MergeMappings();
             mapping.Apply(new Configuration());
-            
+
             model.MergeMappings.ShouldBeTrue();
         }
     }

--- a/src/FluentNHibernate.Testing/Cfg/SQLiteFrameworkConfigurationFactory.cs
+++ b/src/FluentNHibernate.Testing/Cfg/SQLiteFrameworkConfigurationFactory.cs
@@ -1,0 +1,56 @@
+using FluentNHibernate.Cfg.Db;
+using System.Data;
+
+namespace FluentNHibernate.Testing.Cfg
+{
+    public static class SQLiteFrameworkConfigurationFactory
+    {
+#if NETFX
+        internal static SQLiteConfiguration CreateStandardInMemoryConfiguration()
+        {
+            return SQLiteConfiguration.Standard.InMemory();
+        }
+#endif
+
+#if NETCORE
+
+        internal static MsSqliteConfiguration CreateStandardInMemoryConfiguration()
+        {
+            return MsSqliteConfiguration.Standard.InMemory();
+        }
+
+#endif
+
+#if NETFX
+        internal static SQLiteConfiguration CreateStandardConfiguration()
+        {
+            return SQLiteConfiguration.Standard;
+        }
+#endif
+
+#if NETCORE
+
+        internal static MsSqliteConfiguration CreateStandardConfiguration()
+        {
+            return MsSqliteConfiguration.Standard;
+        }
+
+#endif
+
+#if NETFX
+        internal static SQLiteConfiguration CreateStandardConfiguration(IsolationLevel isolationLevel)
+        {
+            return SQLiteConfiguration.Standard.IsolationLevel(isolationLevel);
+        }
+#endif
+
+#if NETCORE
+
+        internal static MsSqliteConfiguration CreateStandardConfiguration(IsolationLevel isolationLevel)
+        {
+            return MsSqliteConfiguration.Standard.IsolationLevel(isolationLevel);
+        }
+
+#endif
+    }
+}

--- a/src/FluentNHibernate.Testing/ConventionFinderTests/AddingTypeTests.cs
+++ b/src/FluentNHibernate.Testing/ConventionFinderTests/AddingTypeTests.cs
@@ -1,11 +1,8 @@
 using System;
 using FluentNHibernate.Conventions;
-using FluentNHibernate.Conventions.AcceptanceCriteria;
 using FluentNHibernate.Conventions.Instances;
-using FluentNHibernate.Conventions.Inspections;
-using FluentNHibernate.Mapping;
-using Machine.Specifications;
 using NUnit.Framework;
+using FluentAssertions;
 
 namespace FluentNHibernate.Testing.ConventionFinderTests
 {
@@ -23,43 +20,42 @@ namespace FluentNHibernate.Testing.ConventionFinderTests
         [Test]
         public void AddingSingleShouldntThrowIfHasParameterlessConstructor()
         {
-            var ex = Catch.Exception(() => finder.Add<ConventionWithParameterlessConstructor>());
+            Action act = () => finder.Add<ConventionWithParameterlessConstructor>();
 
-            ex.ShouldBeNull();
+            act.ShouldNotThrow();
         }
 
         [Test]
         public void AddingSingleShouldntThrowIfHasIConventionFinderConstructor()
         {
-            var ex = Catch.Exception(() => finder.Add<ConventionWithIConventionFinderConstructor>());
+            Action act = () => finder.Add<ConventionWithIConventionFinderConstructor>();
 
-            ex.ShouldBeNull();
+            act.ShouldNotThrow();
+
         }
 
         [Test]
         public void AddingSingleShouldThrowIfNoParameterlessConstructor()
         {
-            var ex = Catch.Exception(() => finder.Add<ConventionWithoutValidConstructor>());
+            Action act = () => finder.Add<ConventionWithoutValidConstructor>();
 
-            ex.ShouldBeOfType<MissingConstructorException>();
-            ex.ShouldNotBeNull();
+            act.ShouldThrow<MissingConstructorException>();
         }
 
         [Test]
         public void AddingSingleShouldThrowIfNoIConventionFinderConstructor()
         {
-            var ex = Catch.Exception(() => finder.Add<ConventionWithoutValidConstructor>());
+            Action act = () => finder.Add<ConventionWithoutValidConstructor>();
 
-            ex.ShouldBeOfType<MissingConstructorException>();
-            ex.ShouldNotBeNull();
+            act.ShouldThrow<MissingConstructorException>();
         }
 
         [Test]
         public void AddingAssemblyShouldntThrowIfNoIConventionFinderConstructor()
         {
-            var ex = Catch.Exception(() => finder.AddAssembly(typeof(ConventionWithoutValidConstructor).Assembly));
+            Action act = () => finder.AddAssembly(typeof(ConventionWithoutValidConstructor).Assembly);
 
-            ex.ShouldBeNull();
+            act.ShouldNotThrow();
         }
     }
 

--- a/src/FluentNHibernate.Testing/DomainModel/ConnectedTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/ConnectedTester.cs
@@ -1,9 +1,9 @@
-﻿using FluentNHibernate.Cfg.Db;
-using FluentNHibernate.Data;
+﻿using FluentNHibernate.Data;
 using FluentNHibernate.Mapping;
 using FluentNHibernate.Testing.Fixtures;
 using NHibernate;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.DomainModel
 {
@@ -15,7 +15,7 @@ namespace FluentNHibernate.Testing.DomainModel
         [SetUp]
         public void SetUp()
         {
-            var properties = new SQLiteConfiguration()
+            var properties = CreateStandardConfiguration()
                 .UseOuterJoin()
                 .InMemory()
                 .ToProperties();
@@ -25,7 +25,7 @@ namespace FluentNHibernate.Testing.DomainModel
         }
 
         [Test]
-        public void MappingTest1()
+        public void Mapping_simple_properties()
         {
             new PersistenceSpecification<Record>(source)
                 .CheckProperty(r => r.Age, 22)
@@ -34,6 +34,7 @@ namespace FluentNHibernate.Testing.DomainModel
                 .VerifyTheMappings();
         }
 
+#if NETFX
         [Test]
         public void Mapping_test_with_arrays()
         {
@@ -41,6 +42,18 @@ namespace FluentNHibernate.Testing.DomainModel
                 .CheckProperty(r => r.BinaryValue, new byte[] { 1, 2, 3 })
                 .VerifyTheMappings();
         }
+#endif
+
+#if NETCORE
+        [Test, Ignore("Currently not supported by Msqlite with NETStandard")]
+        public void Mapping_test_with_arrays()
+        {
+            new PersistenceSpecification<BinaryRecord>(source)
+                .CheckProperty(r => r.BinaryValue, new byte[] { 1, 2, 3 })
+                .VerifyTheMappings();
+        }
+#endif
+
         [Test]
         public void CanWorkWithNestedSubClasses()
         {
@@ -75,7 +88,7 @@ namespace FluentNHibernate.Testing.DomainModel
     }
 
 // ignored warning for obsolete SubClass
-#pragma warning disable 612,618
+#pragma warning disable 612, 618
 
     public sealed class NestedSubClassMap : ClassMap<SuperRecord>
     {
@@ -93,7 +106,7 @@ namespace FluentNHibernate.Testing.DomainModel
         }
     }
 
-#pragma warning restore 612,618
+#pragma warning restore 612, 618
 
     public class SuperRecord  : Entity
     {

--- a/src/FluentNHibernate.Testing/DomainModel/InverseOneToManyTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/InverseOneToManyTester.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using FluentNHibernate.Cfg.Db;
 using FluentNHibernate.Mapping;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.DomainModel
 {
@@ -11,12 +12,12 @@ namespace FluentNHibernate.Testing.DomainModel
         [SetUp]
         public void SetUp()
         {
-            var properties = new SQLiteConfiguration()
+            var properties = CreateStandardConfiguration()
                 .UseOuterJoin()
                 .ShowSql()
                 .InMemory()
                 .ToProperties();
-
+                
             _source = new SingleConnectionSessionSourceForSQLiteInMemoryTesting(properties, new MusicPersistenceModel());
             _source.BuildSchema();
         }

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyIntegrationTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManyIntegrationTester.cs
@@ -1,7 +1,7 @@
-﻿using FluentNHibernate.Cfg.Db;
-using FluentNHibernate.Mapping;
+﻿using FluentNHibernate.Mapping;
 using NUnit.Framework;
 using NHibernate.Cfg;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.DomainModel.Mapping
 {
@@ -38,8 +38,8 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
         [Test]
         public void NHibernateCanLoadOneToManyTargetMapping()
         {
-            var cfg = new SQLiteConfiguration()
-                .InMemory()
+
+            var cfg = CreateStandardInMemoryConfiguration()
                 .ConfigureProperties(new Configuration());
 
             var model = new ManyToManyPersistenceModel();

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManySelfReferencedInverseIntegrationTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/ManyToManySelfReferencedInverseIntegrationTester.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using FluentNHibernate.Cfg.Db;
 using FluentNHibernate.Mapping;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.DomainModel.Mapping
 {
@@ -51,8 +51,7 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
         [Test]
         public void NHibernateCanLoadOneToManyTargetMapping()
         {
-            var cfg = new SQLiteConfiguration()
-                .InMemory()
+            var cfg = CreateStandardInMemoryConfiguration()
                 .ConfigureProperties(new Configuration());
 
             var model = new ManyToManyPersistenceModel();

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/OneToManyIntegrationTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/OneToManyIntegrationTester.cs
@@ -2,6 +2,7 @@
 using FluentNHibernate.Mapping;
 using NUnit.Framework;
 using NHibernate.Cfg;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.DomainModel.Mapping
 {
@@ -42,8 +43,7 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
         [Test]
         public void NHibernateCanLoadOneToManyTargetMapping()
         {
-            var cfg = new SQLiteConfiguration()
-                .InMemory()
+            var cfg = CreateStandardInMemoryConfiguration()
                 .ConfigureProperties(new Configuration());
 
             var model = new OneToManyPersistenceModel();

--- a/src/FluentNHibernate.Testing/DomainModel/Mapping/OneToManyTester.cs
+++ b/src/FluentNHibernate.Testing/DomainModel/Mapping/OneToManyTester.cs
@@ -5,6 +5,7 @@ using FluentNHibernate.Mapping;
 using FluentNHibernate.MappingModel.Collections;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.DomainModel.Mapping
 {
@@ -141,7 +142,8 @@ namespace FluentNHibernate.Testing.DomainModel.Mapping
             var model = new PersistenceModel();
             var classMap = new ClassMap<OneToManyTarget>();
 
-            SQLiteConfiguration.Standard.InMemory().ConfigureProperties(cfg);
+            CreateStandardInMemoryConfiguration()
+                .ConfigureProperties(cfg);
 
             classMap.Id(x => x.Id);
             classMap.HasMany(x => x.SetOfChildren).AsSet<SortComparer>();

--- a/src/FluentNHibernate.Testing/FluentInterfaceTests/TablePerHierarchyTests.cs
+++ b/src/FluentNHibernate.Testing/FluentInterfaceTests/TablePerHierarchyTests.cs
@@ -10,6 +10,7 @@ using FluentNHibernate.Mapping.Providers;
 using FluentNHibernate.Testing.DomainModel.Mapping;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.FluentInterfaceTests
 {
@@ -79,8 +80,7 @@ namespace FluentNHibernate.Testing.FluentInterfaceTests
             cfg = new Configuration();
             model = new PersistenceModel();
 
-            SQLiteConfiguration.Standard
-                .InMemory()
+            CreateStandardInMemoryConfiguration()
                 .ConfigureProperties(cfg);
         }
 

--- a/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
+++ b/src/FluentNHibernate.Testing/FluentNHibernate.Testing.csproj
@@ -2,12 +2,11 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <NoWarn>1591</NoWarn>
-    <PlatformTarget>AnyCpu</PlatformTarget>
-    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp2.0'">Full</DebugType>
   </PropertyGroup>
 
   <Import Project="..\Shared.msbuild" />
-  
+
   <ItemGroup>
     <Compile Remove="ConventionsTests\Defaults\**" />
     <EmbeddedResource Remove="ConventionsTests\Defaults\**" />
@@ -17,9 +16,20 @@
     <EmbeddedResource Include="Fixtures\HbmOne.hbm.xml" />
     <EmbeddedResource Include="Fixtures\HbmTwo.hbm.xml" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\FluentNHibernate\FluentNHibernate.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.1.0-preview1-final" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="FakeItEasy" Version="4.3.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -29,35 +39,16 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Serialization" />
-    <PackageReference Include="FakeItEasy" Version="4.3.0" />
-    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
-    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
-    <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
-
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="FakeItEasy" Version="4.3.0" />
-    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.106" />
-    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.106" />
-    <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.106" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.0-preview1-26216-02" />
   </ItemGroup>
-
 
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>    
+    </Compile>
     <None Include="..\FluentKey.snk">
       <Link>FluentKey.snk</Link>
     </None>

--- a/src/FluentNHibernate.Testing/Infrastructure/ContainerTester.cs
+++ b/src/FluentNHibernate.Testing/Infrastructure/ContainerTester.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using FluentNHibernate.Infrastructure;
-using Machine.Specifications;
 using NUnit.Framework;
+using FluentAssertions;
 
 namespace FluentNHibernate.Testing.Infrastructure
 {
@@ -29,14 +29,10 @@ namespace FluentNHibernate.Testing.Infrastructure
         [Test]
         public void ShouldThrowExceptionWhenResolvingUnregisteredType()
         {
-            var ex = Catch.Exception(() => container.Resolve<IExample>());
+            Action act = () => container.Resolve<IExample>();
 
-            ex
-                .ShouldNotBeNull()
-                .ShouldBeOfType<ResolveException>();
-
-            ex.Message
-                .ShouldEqual("Unable to resolve dependency: '" + typeof(IExample).FullName + "'");
+            act.ShouldThrow<ResolveException>()
+                .WithMessage("Unable to resolve dependency: '" + typeof(IExample).FullName + "'");
         }
 
         private interface IExample

--- a/src/FluentNHibernate.Testing/PersistenceModelTests/JoinPersistenceModelTests.cs
+++ b/src/FluentNHibernate.Testing/PersistenceModelTests/JoinPersistenceModelTests.cs
@@ -1,9 +1,8 @@
-using System.Collections.Generic;
 using System.Linq;
-using FluentNHibernate.Cfg.Db;
 using FluentNHibernate.Mapping;
 using NHibernate.Cfg;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.PersistenceModelTests
 {
@@ -17,9 +16,8 @@ namespace FluentNHibernate.Testing.PersistenceModelTests
         {
             cfg = new Configuration();
 
-            SQLiteConfiguration.Standard.InMemory()
+            CreateStandardInMemoryConfiguration()
                 .ConfigureProperties(cfg);
-
         }
 
         [Test]

--- a/src/FluentNHibernate.Testing/Testing/SessionSourceConfigurationTester.cs
+++ b/src/FluentNHibernate.Testing/Testing/SessionSourceConfigurationTester.cs
@@ -1,8 +1,7 @@
 using FluentNHibernate.Cfg;
-using FluentNHibernate.Cfg.Db;
 using FluentNHibernate.Testing.DomainModel;
-using FluentNHibernate.Testing.Fixtures;
 using NUnit.Framework;
+using static FluentNHibernate.Testing.Cfg.SQLiteFrameworkConfigurationFactory;
 
 namespace FluentNHibernate.Testing.Testing
 {
@@ -55,8 +54,13 @@ namespace FluentNHibernate.Testing.Testing
     {
         public SessionSource build_session_source()
         {
+
+            var configuration = CreateStandardInMemoryConfiguration()
+                    .UseOuterJoin()
+                    .ShowSql();
+
             FluentConfiguration config = Fluently.Configure()
-                .Database(() => new SQLiteConfiguration().InMemory().UseOuterJoin().ShowSql())
+                .Database(() => configuration)
                 .Mappings(m => m.FluentMappings
                     .Add<RecordMap>()
                     .Add<RecordFilter>());

--- a/src/FluentNHibernate/Cfg/Db/ConnectionStringBuilder.cs
+++ b/src/FluentNHibernate/Cfg/Db/ConnectionStringBuilder.cs
@@ -6,19 +6,23 @@ namespace FluentNHibernate.Cfg.Db
     {
         private string connectionString;
 
+#if NETFX
         public ConnectionStringBuilder FromAppSetting(string appSettingKey)
         {
             connectionString = ConfigurationManager.AppSettings[appSettingKey];
             IsDirty = true;
             return this;
         }
+#endif
 
+#if NETFX
         public ConnectionStringBuilder FromConnectionStringWithKey(string connectionStringKey)
         {
             connectionString = ConfigurationManager.ConnectionStrings[connectionStringKey].ConnectionString;
             IsDirty = true;
             return this;
         }
+#endif
 
         public ConnectionStringBuilder Is(string rawConnectionString)
         {

--- a/src/FluentNHibernate/FluentNHibernate.csproj
+++ b/src/FluentNHibernate/FluentNHibernate.csproj
@@ -1,47 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
     <NoWarn>1591</NoWarn>
     <PlatformTarget>AnyCpu</PlatformTarget>
     <OutputType>Library</OutputType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <Description>FluentNHibernate</Description>
   </PropertyGroup>
-  
-  
+
+
   <PropertyGroup>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)..\Shared.msbuild" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup>
     <PackageReference Include="NHibernate" Version="5.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.configuration" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="NHibernate" Version="5.1.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
-  </ItemGroup>
-
-
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>  
+    </Compile>
     <None Include="..\FluentKey.snk">
       <Link>FluentKey.snk</Link>
     </None>

--- a/src/FluentNHibernate/Infrastructure/NetStandardSerialization.cs
+++ b/src/FluentNHibernate/Infrastructure/NetStandardSerialization.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using static FluentNHibernate.Infrastructure.Serialization;
+
+namespace FluentNHibernate.Infrastructure
+{
+    /// <summary>
+    /// Reference Via: https://github.com/CXuesong/BotBuilder.Standard/blob/netcore20%2Bnet45/CSharp/Library/Microsoft.Bot.Builder/Fibers/NetStandardSerialization.cs
+    /// </summary>
+    public static class NetStandardSerialization
+    {
+        public sealed class TypeSerializationSurrogate : ISurrogateProvider
+        {
+            public void GetObjectData(object obj, SerializationInfo info, StreamingContext context)
+            {
+                var type = (Type)obj;
+                // BinaryFormatter in .NET Core 2.0 cannot persist types in System.Private.CoreLib.dll
+                // that are not forwareded to mscorlib, including System.RuntimeType
+                info.SetType(typeof(TypeReference));
+                info.AddValue("AssemblyName", type.Assembly.FullName);
+                info.AddValue("FullName", type.FullName);
+            }
+
+            public object SetObjectData(
+                object obj, SerializationInfo info,
+                StreamingContext context,
+                ISurrogateSelector selector) => throw new NotSupportedException();
+
+            public bool Handles(Type type, StreamingContext context) => typeof(Type).IsAssignableFrom(type);
+
+            [Serializable]
+            internal sealed class TypeReference : IObjectReference
+            {
+                private readonly string AssemblyName;
+
+                private readonly string FullName;
+
+                public TypeReference(Type type)
+                {
+                    if (type == null)
+                        throw new ArgumentNullException(nameof(type));
+
+                    AssemblyName = type.Assembly.FullName;
+                    FullName = type.FullName;
+                }
+
+                public object GetRealObject(StreamingContext context)
+                {
+                    var assembly = Assembly.Load(AssemblyName);
+                    return assembly.GetType(FullName, true);
+                }
+            }
+        }
+
+        public sealed class MemberInfoSerializationSurrogate : ISurrogateProvider
+        {
+            public void GetObjectData(object obj, SerializationInfo info, StreamingContext context) =>
+                MemberInfoReference.GetObjectData((MemberInfo)obj, info, context);
+
+            public object SetObjectData(
+                object obj,
+                SerializationInfo info,
+                StreamingContext context,
+                ISurrogateSelector selector) =>
+                throw new NotSupportedException();
+
+            public bool Handles(Type type, StreamingContext context) => typeof(MemberInfo).IsAssignableFrom(type);
+
+            [Serializable]
+            private sealed class MemberInfoReference : IObjectReference
+            {
+                private readonly Type DeclaringType = null;
+                private readonly string Name = null;
+                private readonly MemberTypes MemberType = default(MemberTypes);
+                private readonly BindingFlags BindingAttr = default(BindingFlags);
+                private readonly Type[] GenericParameters = null;
+                private readonly Type[] Parameters = null;
+
+                private static BindingFlags GetBindingAttr(MemberInfo member)
+                {
+                    if (member == null) throw new ArgumentNullException(nameof(member));
+                    var bindingFlags = default(BindingFlags);
+                    switch (member)
+                    {
+                        case MethodBase method:
+                            bindingFlags |= method.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic;
+                            bindingFlags |= method.IsStatic ? BindingFlags.Static : BindingFlags.Instance;
+                            break;
+
+                        case FieldInfo field:
+                            bindingFlags |= field.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic;
+                            bindingFlags |= field.IsStatic ? BindingFlags.Static : BindingFlags.Instance;
+                            break;
+
+                        default:
+                            return BindingFlags.Public | BindingFlags.NonPublic
+                                   | BindingFlags.Static | BindingFlags.Instance;
+                    }
+                    return bindingFlags;
+                }
+
+                public static void GetObjectData(MemberInfo member, SerializationInfo info, StreamingContext context)
+                {
+                    info.SetType(typeof(MemberInfoReference));
+                    info.AddValue(nameof(DeclaringType), new TypeSerializationSurrogate.TypeReference(member.DeclaringType));
+                    info.AddValue(nameof(Name), member.Name);
+                    info.AddValue(nameof(MemberType), member.MemberType);
+                    info.AddValue(nameof(BindingAttr), GetBindingAttr(member));
+                    if (member is MethodBase method)
+                    {
+                        info.AddValue(nameof(GenericParameters),
+                            method.GetGenericArguments().ToArray());
+                        info.AddValue(nameof(Parameters),
+                            method.GetParameters().Select(p => p.ParameterType).ToArray());
+                    }
+                }
+
+                private bool MatchMethodSignature(MethodBase method)
+                {
+                    Debug.Assert(method.Name == Name);
+                    var gpa = method.GetGenericArguments();
+                    if (gpa.Length != GenericParameters.Length) return false;
+                    var pa = method.GetParameters();
+                    if (pa.Length != Parameters.Length) return false;
+                    if (gpa.Length > 0)
+                    {
+                        var genericMethod = ((MethodInfo)method).MakeGenericMethod(GenericParameters);
+                        pa = genericMethod.GetParameters();
+                    }
+                    for (int i = 0; i < pa.Length; i++)
+                    {
+                        if (pa[i].ParameterType != Parameters[i]) return false;
+                    }
+                    return true;
+                }
+
+                public object GetRealObject(StreamingContext context)
+                {
+                    if (MemberType == MemberTypes.Method || MemberType == MemberTypes.Constructor)
+                    {
+                        var methods = DeclaringType.GetMember(Name, MemberType, BindingAttr | BindingFlags.DeclaredOnly);
+                        if (Parameters.Any(t => t == null))
+                            throw new ArgumentException("Detected null argument type in the method signature.",
+                                nameof(Parameters));
+                        if (Parameters.Any(t => t.IsGenericParameter))
+                            throw new ArgumentException("Detected generic parameter in the method signature.",
+                                nameof(Parameters));
+                        try
+                        {
+                            return methods.Cast<MethodBase>().First(MatchMethodSignature);
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            throw new MissingMethodException(DeclaringType.FullName, Name);
+                        }
+                    }
+                    var members = DeclaringType.GetMember(Name, MemberType, BindingAttr | BindingFlags.DeclaredOnly);
+                    if (members.Length == 0) throw new MissingMemberException(DeclaringType.FullName, Name);
+                    if (members.Length > 1)
+                        throw new AmbiguousMatchException($"Found multiple \"{Name}\" in \"{DeclaringType}\".");
+                    return members[0];
+                }
+            }
+        }
+
+        public sealed class SurrogateSelector : ISurrogateSelector
+        {
+            private readonly ISurrogateProvider _typeSerializationProvider;
+            private readonly ISurrogateProvider _memberInfoSerializationProvider;
+
+            public SurrogateSelector()
+            {
+                _typeSerializationProvider = new TypeSerializationSurrogate();
+                _memberInfoSerializationProvider = new MemberInfoSerializationSurrogate();
+            }
+
+            void ISurrogateSelector.ChainSelector(ISurrogateSelector selector) => throw new NotImplementedException();
+
+            ISurrogateSelector ISurrogateSelector.GetNextSelector() => throw new NotImplementedException();
+
+            ISerializationSurrogate ISurrogateSelector.GetSurrogate(Type type, StreamingContext context, out ISurrogateSelector selector)
+            {
+                if (_typeSerializationProvider.Handles(type, context))
+                {
+                    selector = this;
+                    return _typeSerializationProvider;
+                }
+
+                if (_memberInfoSerializationProvider.Handles(type, context))
+                {
+                    selector = this;
+                    return _memberInfoSerializationProvider;
+                }
+
+                selector = null;
+                return null;
+            }
+        }
+    }
+}

--- a/src/FluentNHibernate/Infrastructure/Serialization.cs
+++ b/src/FluentNHibernate/Infrastructure/Serialization.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace FluentNHibernate.Infrastructure
+{
+    public static class Serialization
+    {
+        /// <summary>
+        /// Extend <see cref="ISerializationSurrogate"/> with a "tester" method used by <see cref="SurrogateSelector"/>.
+        /// Reference Via: https://github.com/CXuesong/BotBuilder.Standard/blob/netcore20%2Bnet45/CSharp/Library/Microsoft.Bot.Builder/Fibers/NetStandardSerialization.cs
+        /// </summary>
+        public interface ISurrogateProvider : ISerializationSurrogate
+        {
+            /// <summary>
+            /// Determine whether this surrogate provider handles this type.
+            /// </summary>
+            /// <param name="type">The query type.</param>
+            /// <param name="context">The serialization context.</param>
+            /// <returns>True if this provider handles this type, false otherwise.</returns>
+            bool Handles(Type type, StreamingContext context);
+        }
+    }
+}

--- a/src/FluentNHibernate/Mapping/SubclassMap.cs
+++ b/src/FluentNHibernate/Mapping/SubclassMap.cs
@@ -352,7 +352,7 @@ namespace FluentNHibernate.Mapping
 
         string GetDefaultTableName()
         {
-#pragma warning disable 612,618
+#pragma warning disable 612, 618
             var tableName = EntityType.Name;
 
             if (EntityType.IsGenericType)
@@ -366,7 +366,7 @@ namespace FluentNHibernate.Mapping
                     tableName += argument.Name;
                 }
             }
-#pragma warning restore 612,618
+#pragma warning restore 612, 618
 
             return "`" + tableName + "`";
         }

--- a/src/FluentNHibernate/MappingModel/ClassBased/ComponentType.cs
+++ b/src/FluentNHibernate/MappingModel/ClassBased/ComponentType.cs
@@ -22,9 +22,15 @@ namespace FluentNHibernate.MappingModel.ClassBased
 
         public override bool Equals(object obj)
         {
-            if (obj is ComponentType)
-                return Equals(obj as ComponentType);
-            return false;
+            if (obj.GetType() != typeof(ComponentType))
+                return false;
+
+            return Equals(obj as ComponentType);
+        }
+
+        public override string ToString()
+        {
+            return string.Format("ElementName: {0}", elementName);
         }
 
         public bool Equals(ComponentType other)
@@ -35,6 +41,16 @@ namespace FluentNHibernate.MappingModel.ClassBased
         public override int GetHashCode()
         {
             return (elementName != null ? elementName.GetHashCode() : 0);
+        }
+
+        public static bool operator ==(ComponentType left, ComponentType right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(ComponentType left, ComponentType right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/src/FluentNHibernate/MappingModel/ClassBased/SubclassMapping.cs
+++ b/src/FluentNHibernate/MappingModel/ClassBased/SubclassMapping.cs
@@ -152,7 +152,9 @@ namespace FluentNHibernate.MappingModel.ClassBased
             unchecked
             {
                 {
-                    return (base.GetHashCode() * 397) ^ (attributes != null ? attributes.GetHashCode() : 0);
+                    return (base.GetHashCode() * 397) ^ (attributes != null
+                        ? attributes.GetHashCode()
+                        : 0);
                 }
             }
         }

--- a/src/FluentNHibernate/MappingModel/ClassBased/SubclassType.cs
+++ b/src/FluentNHibernate/MappingModel/ClassBased/SubclassType.cs
@@ -28,7 +28,9 @@ namespace FluentNHibernate.MappingModel.ClassBased
 
         public override bool Equals(object obj)
         {
-            if (obj.GetType() != typeof(SubclassType)) return false;
+            if (obj.GetType() != typeof(SubclassType))
+                return false;
+
             return Equals((SubclassType)obj);
         }
 

--- a/src/FluentNHibernate/UnknownPropertyException.cs
+++ b/src/FluentNHibernate/UnknownPropertyException.cs
@@ -15,11 +15,12 @@ namespace FluentNHibernate
         }
 
         public string Property { get; private set; }
+
         public Type Type { get; private set; }
 
         protected UnknownPropertyException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-            this.Type = info.GetValue("Type", typeof(Type)) as Type;
+            this.Type = Type.GetType(info.GetString("TypeFullName"));
             this.Property = info.GetString("Property");
         }
 
@@ -27,7 +28,7 @@ namespace FluentNHibernate
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             base.GetObjectData(info, context);
-            info.AddValue("Type", Type, typeof(Type));
+            info.AddValue("TypeFullName", Type.FullName);
             info.AddValue("Property", Property);
         }
     }

--- a/src/FluentNHibernate/Utils/Extensions.cs
+++ b/src/FluentNHibernate/Utils/Extensions.cs
@@ -1,9 +1,11 @@
+using FluentNHibernate.Automapping.Alterations;
+using FluentNHibernate.Infrastructure;
+using NHibernate.Util;
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-using FluentNHibernate.Automapping.Alterations;
-using NHibernate.Util;
 
 namespace FluentNHibernate.Utils
 {
@@ -11,7 +13,7 @@ namespace FluentNHibernate.Utils
     {
         public static bool In<T>(this T instance, params T[] expected)
         {
-            if(ReferenceEquals(instance, null))
+            if (ReferenceEquals(instance, null))
                 return false;
             return expected.Any(x => instance.Equals(x));
         }
@@ -43,7 +45,7 @@ namespace FluentNHibernate.Utils
         {
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
-    
+
         public static T InstantiateUsingParameterlessConstructor<T>(this Type type)
         {
             return (T)type.InstantiateUsingParameterlessConstructor();
@@ -68,10 +70,17 @@ namespace FluentNHibernate.Utils
         {
             using (var stream = new MemoryStream())
             {
+
+#if NETFX
                 var formatter = new BinaryFormatter();
-                
+#endif
+
+#if NETCORE
+                var formatter = new BinaryFormatter(new NetStandardSerialization.SurrogateSelector(), new StreamingContext());
+#endif
+
                 formatter.Serialize(stream, obj);
-                stream.Position = 0;
+                stream.Seek(0, SeekOrigin.Begin);
 
                 return (T)formatter.Deserialize(stream);
             }


### PR DESCRIPTION
Implements #390 

Finally we can release FluentNHibernate for netstandard2.0 and netcoreapp2.0. 

In general, most of the problems we had to move to NETCore were for serialization. Since by default some types are not supported by the framework (System.Type, MemberInfo, etc).

Changes:
* App.config and ConfigurationManager can only be used with NETFX (Full framework). For the rest of frameworks you need to specify the full connection string.
* Added MsSQLiteDriver and MsqliteConfiguration to connect with [Microsoft SQLite NETStandard](https://github.com/aspnet/Microsoft.Data.Sqlite) in memory implementation. Mostly used for testing purposes on NETStandard and NETCore, FX testings remains with SQLIte normal implementation.
* Adapted DeepClone binary serializer for NETStandard and NETCore using subrrogates for custom serialization of types not supported by NETCore.