### PR TITLE
Generate all mappings in the order they were declared.

### DIFF
--- a/src/FluentNHibernate/Mapping/ClassMap.cs
+++ b/src/FluentNHibernate/Mapping/ClassMap.cs
@@ -618,55 +618,69 @@ namespace FluentNHibernate.Mapping
             mapping.Set(x => x.Type, Layer.Defaults, typeof(T));
             mapping.Set(x => x.Name, Layer.Defaults, typeof(T).AssemblyQualifiedName);
 
-            foreach (var property in providers.Properties)
-                mapping.AddProperty(property.GetPropertyMapping());
-
-            foreach (var component in providers.Components)
-                mapping.AddComponent(component.GetComponentMapping());
-
             if (providers.Version != null)
-                mapping.Set(x => x.Version, Layer.Defaults, providers.Version.GetVersionMapping());
+              mapping.Set(x => x.Version, Layer.Defaults, providers.Version.GetVersionMapping());
 
-            foreach (var oneToOne in providers.OneToOnes)
-                mapping.AddOneToOne(oneToOne.GetOneToOneMapping());
-
-            foreach (var collection in providers.Collections)
-                mapping.AddCollection(collection.GetCollectionMapping());
-
-            foreach (var reference in providers.References)
-                mapping.AddReference(reference.GetManyToOneMapping());
-
-            foreach (var any in providers.Anys)
-                mapping.AddAny(any.GetAnyMapping());
-
-            foreach (var subclass in providers.Subclasses.Values)
-                mapping.AddSubclass(subclass.GetSubclassMapping());
-
-            foreach (var join in providers.Joins)
-                mapping.AddJoin(join.GetJoinMapping());
-
-            if (providers.Discriminator != null)
-                mapping.Set(x => x.Discriminator, Layer.Defaults, providers.Discriminator.GetDiscriminatorMapping());
+            foreach (var provider in providers.OrderedProviders) {
+                var x = provider.Item2;
+                switch (provider.Item1) {
+                    case MappingProviderStore.ProviderType.Property:
+                        mapping.AddProperty(((IPropertyMappingProvider) x).GetPropertyMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Component:
+                        mapping.AddComponent(((IComponentMappingProvider) x).GetComponentMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.OneToOne:
+                        mapping.AddOneToOne(((IOneToOneMappingProvider) x).GetOneToOneMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Subclass:
+                        mapping.AddSubclass(((ISubclassMappingProvider) x).GetSubclassMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Collection:
+                        mapping.AddCollection(((ICollectionMappingProvider) x).GetCollectionMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.ManyToOne:
+                        mapping.AddReference(((IManyToOneMappingProvider) x).GetManyToOneMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Any:
+                        mapping.AddAny(((IAnyMappingProvider) x).GetAnyMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Filter:
+                        mapping.AddFilter(((IFilterMappingProvider) x).GetFilterMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.StoredProcedure:
+                        mapping.AddStoredProcedure(((IStoredProcedureMappingProvider) x).GetStoredProcedureMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Join:
+                        mapping.AddJoin(((IJoinMappingProvider) x).GetJoinMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Identity:
+                        mapping.Set(y => y.Id, Layer.Defaults, ((IIdentityMappingProvider) x).GetIdentityMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.CompositeId:
+                        mapping.Set(y => y.Id, Layer.Defaults, ((ICompositeIdMappingProvider) x).GetCompositeIdMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.NaturalId:
+                        mapping.Set(y => y.NaturalId, Layer.Defaults, ((INaturalIdMappingProvider) x).GetNaturalIdMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Version:
+                        mapping.Set(y => y.Version, Layer.Defaults, ((IVersionMappingProvider) x).GetVersionMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Discriminator:
+                        mapping.Set(y => y.Discriminator, Layer.Defaults, ((IDiscriminatorMappingProvider) x).GetDiscriminatorMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Tupilizer:
+                        mapping.Set(y => y.Tuplizer, Layer.Defaults, (TuplizerMapping)x);
+                        break;
+                    default:
+                        throw new Exception("Internal Error");
+                }
+            }
 
             if (Cache.IsDirty)
                 mapping.Set(x  => x.Cache, Layer.Defaults, ((ICacheMappingProvider)Cache).GetCacheMapping());
 
-            if (providers.Id != null)
-                mapping.Set(x => x.Id, Layer.Defaults, providers.Id.GetIdentityMapping());
-
-            if (providers.CompositeId != null)
-                mapping.Set(x => x.Id, Layer.Defaults, providers.CompositeId.GetCompositeIdMapping());
-
-            if (providers.NaturalId != null)
-                mapping.Set(x => x.NaturalId, Layer.Defaults, providers.NaturalId.GetNaturalIdMapping());
-
             mapping.Set(x => x.TableName, Layer.Defaults, GetDefaultTableName());
-
-            foreach (var filter in providers.Filters)
-                mapping.AddFilter(filter.GetFilterMapping());
-
-            foreach (var storedProcedure in providers.StoredProcedures)
-                mapping.AddStoredProcedure(storedProcedure.GetStoredProcedureMapping());
 
             mapping.Set(x => x.Tuplizer, Layer.Defaults, providers.TuplizerMapping);
 

--- a/src/FluentNHibernate/Mapping/MappingProviderStore.cs
+++ b/src/FluentNHibernate/Mapping/MappingProviderStore.cs
@@ -1,42 +1,227 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
 using FluentNHibernate.Mapping.Providers;
 using FluentNHibernate.MappingModel;
+using FluentNHibernate.Utils;
 
 namespace FluentNHibernate.Mapping
 {
     public class MappingProviderStore
     {
+        public enum ProviderType {
+            Property,
+            Component,
+            OneToOne,
+            Subclass,
+            Collection,
+            ManyToOne,
+            Any,
+            Filter,
+            StoredProcedure,
+            Join,
+            Identity,
+            CompositeId,
+            NaturalId,
+            Version,
+            Discriminator,
+            Tupilizer
+        }
+
         public IList<IPropertyMappingProvider> Properties { get; set; }
         public IList<IComponentMappingProvider> Components { get; set; }
         public IList<IOneToOneMappingProvider> OneToOnes { get; set; }
-        public Dictionary<Type, ISubclassMappingProvider> Subclasses { get; set; }
+        public IDictionary<Type, ISubclassMappingProvider> Subclasses { get; set; }
         public IList<ICollectionMappingProvider> Collections { get; set; }
         public IList<IManyToOneMappingProvider> References { get; set; }
         public IList<IAnyMappingProvider> Anys { get; set; }
         public IList<IFilterMappingProvider> Filters { get; set; }
         public IList<IStoredProcedureMappingProvider> StoredProcedures { get; set; }
         public IList<IJoinMappingProvider> Joins { get; set; }
+        private IIdentityMappingProvider _id;
+        private ICompositeIdMappingProvider _compositeId;
+        private INaturalIdMappingProvider _naturalId;
+        private IVersionMappingProvider _version;
+        private IDiscriminatorMappingProvider _discriminator;
+        private TuplizerMapping _tuplizerMapping;
+        private IList<Tuple<ProviderType, object>> orderedProviders;
 
-        public IIdentityMappingProvider Id { get; set; }
-        public ICompositeIdMappingProvider CompositeId { get; set; }
-        public INaturalIdMappingProvider NaturalId { get; set; }
-        public IVersionMappingProvider Version { get; set; }
-        public IDiscriminatorMappingProvider Discriminator { get; set; }
-        public TuplizerMapping TuplizerMapping { get; set; }
+
+        public IIdentityMappingProvider Id {
+            get {
+                return _id;
+            }
+            set {
+                ReplaceOrAddProvider(ProviderType.Identity, _id, value);
+                _id = value;
+            }
+        }
+
+        public ICompositeIdMappingProvider CompositeId {
+            get {
+                return _compositeId;
+            }
+            set {
+                ReplaceOrAddProvider(ProviderType.CompositeId, _compositeId, value);
+                _compositeId = value;
+            }
+        }
+
+        public INaturalIdMappingProvider NaturalId {
+            get {
+                return _naturalId;
+            }
+            set {
+                ReplaceOrAddProvider(ProviderType.NaturalId, _naturalId, value);
+                _naturalId = value;
+            }
+        }
+
+        public IVersionMappingProvider Version {
+            get {
+                return _version;
+            }
+            set {
+                ReplaceOrAddProvider(ProviderType.Version, _version, value);
+                _version = value;
+            }
+        }
+
+        public IDiscriminatorMappingProvider Discriminator {
+            get {
+                return _discriminator;
+            }
+            set {
+                ReplaceOrAddProvider(ProviderType.Discriminator, _discriminator, value);
+                _discriminator = value;
+            }
+        }
+
+        public TuplizerMapping TuplizerMapping {
+            get {
+                return _tuplizerMapping;
+            }
+            set {
+                ReplaceOrAddProvider(ProviderType.Tupilizer, _tuplizerMapping, value);
+                _tuplizerMapping = value;
+            }
+        }
 
         public MappingProviderStore()
-        {
-            Properties = new List<IPropertyMappingProvider>();
-            Components = new List<IComponentMappingProvider>();
-            OneToOnes = new List<IOneToOneMappingProvider>();
-            Subclasses = new Dictionary<Type, ISubclassMappingProvider>();
-            Collections = new List<ICollectionMappingProvider>();
-            References = new List<IManyToOneMappingProvider>();
-            Anys = new List<IAnyMappingProvider>();
-            Filters = new List<IFilterMappingProvider>();
-            StoredProcedures = new List<IStoredProcedureMappingProvider>();
-            Joins = new List<IJoinMappingProvider>();
+        {            
+            Properties = NewObservedList<IPropertyMappingProvider>();
+            Components = NewObservedList<IComponentMappingProvider>();
+            OneToOnes = NewObservedList<IOneToOneMappingProvider>();
+            Subclasses = NewObservedDictionary<Type, ISubclassMappingProvider>();
+            Collections = NewObservedList<ICollectionMappingProvider>();
+            References = NewObservedList<IManyToOneMappingProvider>();
+            Anys = NewObservedList<IAnyMappingProvider>();
+            Filters = NewObservedList<IFilterMappingProvider>();
+            StoredProcedures = NewObservedList<IStoredProcedureMappingProvider>();
+            Joins = NewObservedList<IJoinMappingProvider>();
+            orderedProviders = new List<Tuple<ProviderType, object>>();
         }
+
+        public IEnumerable<Tuple<ProviderType, object>> OrderedProviders {
+            get { return orderedProviders.Select(x => x); }
+        }
+
+        private IList<T> NewObservedList<T>() {
+
+            ProviderType TypeSelector(object o) 
+            {
+                if (ReferenceEquals(o, Properties)) {
+                    return ProviderType.Property;
+                } else if (ReferenceEquals(o, Components)) {
+                    return ProviderType.Component;
+                } else if (ReferenceEquals(o, OneToOnes)) {
+                    return ProviderType.OneToOne;
+                } else if (ReferenceEquals(o, Collections)) {
+                    return ProviderType.Collection;
+                } else if (ReferenceEquals(o, References)) {
+                    return ProviderType.ManyToOne;
+                } else if (ReferenceEquals(o, Anys)) {
+                    return ProviderType.Any;
+                } else if (ReferenceEquals(o, Filters)) {
+                    return ProviderType.Filter;
+                } else if (ReferenceEquals(o, StoredProcedures)) {
+                    return ProviderType.StoredProcedure;
+                } else if (ReferenceEquals(o, Joins)) {
+                    return ProviderType.Join;
+                }
+                throw new Exception("Internal Error");
+            }
+
+            var observableList = new ObservableCollection<T>();
+            observableList.CollectionChanged += (sender, args) => {
+                var type = TypeSelector(sender);
+                switch (args.Action) {
+                    case NotifyCollectionChangedAction.Add:
+                        foreach (var newItem in args.NewItems)
+                            orderedProviders.Add(Tuple.Create(type, newItem));
+                        break;
+                    case NotifyCollectionChangedAction.Move:
+                        throw new NotSupportedException();
+
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (var oldItem in args.OldItems)
+                            orderedProviders.Remove(Tuple.Create(type, oldItem));
+                        break;
+                    case NotifyCollectionChangedAction.Replace:
+                        throw new NotSupportedException();
+                    case NotifyCollectionChangedAction.Reset:
+                        foreach (var oldItem in args.OldItems)
+                            orderedProviders.Remove(Tuple.Create(type, oldItem));
+                        break;
+                }
+            };
+            return observableList;
+        }
+
+        private IDictionary<TKey, TVal> NewObservedDictionary<TKey, TVal>() {
+            var observedDictionary = new ObservableDictionary<TKey,TVal>();
+            observedDictionary.CollectionChanged += (sender, args) => {
+                switch (args.Action) {
+                    case NotifyCollectionChangedAction.Add:
+                        if (args.NewStartingIndex < ((IDictionary<TKey, TVal>)sender).Count) {
+                            //Inserting
+                            for (var i = 0; i < args.NewItems.Count; i++) {
+                                var newValue = (KeyValuePair<TKey, TVal>)args.NewItems[i];
+                                orderedProviders.Insert(args.NewStartingIndex + i, Tuple.Create(ProviderType.Subclass, (object)newValue.Value));
+                            }
+                        } else {
+                            //Appending
+                            foreach (KeyValuePair<TKey, TVal> newItem in args.NewItems) {
+                                orderedProviders.Add(Tuple.Create(ProviderType.Subclass, (object)newItem.Value));
+                            }
+                        }
+                        break;
+                    case NotifyCollectionChangedAction.Move:
+                        throw new NotSupportedException();
+                    case NotifyCollectionChangedAction.Remove:
+                        foreach (KeyValuePair<TKey, TVal> oldItem in args.OldItems)
+                            orderedProviders.Remove(Tuple.Create(ProviderType.Subclass, (object)oldItem.Value));
+                        break;
+                    case NotifyCollectionChangedAction.Replace:
+                        throw new NotSupportedException();                        
+                    case NotifyCollectionChangedAction.Reset:
+                        foreach (KeyValuePair<TKey, TVal> oldItem in args.OldItems)
+                            orderedProviders.Remove(Tuple.Create(ProviderType.Subclass, (object)oldItem.Value));
+                        break;
+                }
+            };
+            return observedDictionary;            
+        }
+
+        private void ReplaceOrAddProvider(ProviderType type, object oldObj, object newObj) {
+            var index = orderedProviders.IndexOf(Tuple.Create(type, oldObj));
+            var newObjTuple = Tuple.Create(type, newObj);
+            if (index > 0)
+                orderedProviders[index] = newObjTuple;
+            else
+                orderedProviders.Add(newObjTuple);
+        }        
     }
 }

--- a/src/FluentNHibernate/Mapping/SubclassMap.cs
+++ b/src/FluentNHibernate/Mapping/SubclassMap.cs
@@ -309,23 +309,41 @@ namespace FluentNHibernate.Mapping
             foreach (var join in joins)
                 mapping.AddJoin(join);
 
-            foreach (var property in providers.Properties)
-                mapping.AddProperty(property.GetPropertyMapping());
-
-            foreach (var component in providers.Components)
-                mapping.AddComponent(component.GetComponentMapping());
-
-            foreach (var oneToOne in providers.OneToOnes)
-                mapping.AddOneToOne(oneToOne.GetOneToOneMapping());
-
-            foreach (var collection in providers.Collections)
-                mapping.AddCollection(collection.GetCollectionMapping());
-
-            foreach (var reference in providers.References)
-                mapping.AddReference(reference.GetManyToOneMapping());
-
-            foreach (var any in providers.Anys)
-                mapping.AddAny(any.GetAnyMapping());
+            foreach (var provider in providers.OrderedProviders) {
+                var x = provider.Item2;
+                switch (provider.Item1) {
+                    case MappingProviderStore.ProviderType.Property:
+                        mapping.AddProperty(((IPropertyMappingProvider)x).GetPropertyMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Component:
+                        mapping.AddComponent(((IComponentMappingProvider)x).GetComponentMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.OneToOne:
+                        mapping.AddOneToOne(((IOneToOneMappingProvider)x).GetOneToOneMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Collection:
+                        mapping.AddCollection(((ICollectionMappingProvider)x).GetCollectionMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.ManyToOne:
+                        mapping.AddReference(((IManyToOneMappingProvider)x).GetManyToOneMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Any:
+                        mapping.AddAny(((IAnyMappingProvider)x).GetAnyMapping());
+                        break;
+                    case MappingProviderStore.ProviderType.Subclass:
+                    case MappingProviderStore.ProviderType.Filter:
+                    case MappingProviderStore.ProviderType.StoredProcedure:
+                    case MappingProviderStore.ProviderType.Join:
+                    case MappingProviderStore.ProviderType.Identity:
+                    case MappingProviderStore.ProviderType.CompositeId:
+                    case MappingProviderStore.ProviderType.NaturalId:
+                    case MappingProviderStore.ProviderType.Version:
+                    case MappingProviderStore.ProviderType.Discriminator:
+                    case MappingProviderStore.ProviderType.Tupilizer:
+                    default:
+                        throw new Exception("Internal Error");
+                }
+            }
 
             return mapping.DeepClone();
         }

--- a/src/FluentNHibernate/MappingModel/MappedMembers.cs
+++ b/src/FluentNHibernate/MappingModel/MappedMembers.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FluentNHibernate.MappingModel.ClassBased;
+using FluentNHibernate.Utils;
 using FluentNHibernate.Visitors;
 
 namespace FluentNHibernate.MappingModel
@@ -8,211 +11,168 @@ namespace FluentNHibernate.MappingModel
     [Serializable]
     internal class MappedMembers : IMapping, IHasMappedMembers
     {
-        private readonly List<PropertyMapping> properties;
-        private readonly List<Collections.CollectionMapping> collections;
-        private readonly List<ManyToOneMapping> references;
-        private readonly List<IComponentMapping> components;
-        private readonly List<OneToOneMapping> oneToOnes;
-        private readonly List<AnyMapping> anys;
-        private readonly List<JoinMapping> joins;
-        private readonly List<FilterMapping> filters;
-        private readonly List<StoredProcedureMapping> storedProcedures;
+        public enum MappingType {
+            Property,
+            Collection,
+            ManyToOne,
+            IComponent,
+            OneToOne,
+            Any,
+            Join,
+            Filter,
+            StoredProcedure,
+        }
+
+        private readonly List<Tuple<MappingType, IMapping>> orderedMappings;
 
         public MappedMembers()
         {
-            properties = new List<PropertyMapping>();
-            collections = new List<Collections.CollectionMapping>();
-            references = new List<ManyToOneMapping>();
-            components = new List<IComponentMapping>();
-            oneToOnes = new List<OneToOneMapping>();
-            anys = new List<AnyMapping>();
-            joins = new List<JoinMapping>();
-            filters = new List<FilterMapping>();
-            storedProcedures = new List<StoredProcedureMapping>();
+            orderedMappings = new List<Tuple<MappingType, IMapping>>();
         }
 
-        public IEnumerable<PropertyMapping> Properties
-        {
-            get { return properties; }
-        }
+        public IEnumerable<PropertyMapping> Properties => orderedMappings.Where(x => x.Item1 == MappingType.Property).Select(x => x.Item2).Cast<PropertyMapping>();
 
-        public IEnumerable<Collections.CollectionMapping> Collections
-        {
-            get { return collections; }
-        }
+        public IEnumerable<Collections.CollectionMapping> Collections => orderedMappings.Where(x => x.Item1 == MappingType.Collection).Select(x => x.Item2).Cast<Collections.CollectionMapping>();
 
-        public IEnumerable<ManyToOneMapping> References
-        {
-            get { return references; }
-        }
+        public IEnumerable<ManyToOneMapping> References => orderedMappings.Where(x => x.Item1 == MappingType.ManyToOne).Select(x => x.Item2).Cast<ManyToOneMapping>();
 
-        public IEnumerable<IComponentMapping> Components
-        {
-            get { return components; }
-        }
+        public IEnumerable<IComponentMapping> Components => orderedMappings.Where(x => x.Item1 == MappingType.IComponent).Select(x => x.Item2).Cast<IComponentMapping>();
 
-        public IEnumerable<OneToOneMapping> OneToOnes
-        {
-            get { return oneToOnes; }
-        }
+        public IEnumerable<OneToOneMapping> OneToOnes => orderedMappings.Where(x => x.Item1 == MappingType.OneToOne).Select(x => x.Item2).Cast<OneToOneMapping>();
 
-        public IEnumerable<AnyMapping> Anys
-        {
-            get { return anys; }
-        }
+        public IEnumerable<AnyMapping> Anys => orderedMappings.Where(x => x.Item1 == MappingType.Any).Select(x => x.Item2).Cast<AnyMapping>();
 
-        public IEnumerable<JoinMapping> Joins
-        {
-            get { return joins; }
-        }
+        public IEnumerable<JoinMapping> Joins => orderedMappings.Where(x => x.Item1 == MappingType.Join).Select(x => x.Item2).Cast<JoinMapping>();
 
-        public IEnumerable<FilterMapping> Filters
-        {
-            get { return filters; }
-        }
+        public IEnumerable<FilterMapping> Filters => orderedMappings.Where(x => x.Item1 == MappingType.Filter).Select(x => x.Item2).Cast<FilterMapping>();
+
+        public IEnumerable<StoredProcedureMapping> StoredProcedures => orderedMappings.Where(x => x.Item1 == MappingType.StoredProcedure).Select(x => x.Item2).Cast<StoredProcedureMapping>();
 
         public void AddOrReplaceFilter(FilterMapping mapping)
         {
-            var filter = filters.Find(x => x.Name == mapping.Name);
-            if (filter != null)
-                filters.Remove(filter);
-            filters.Add(mapping);
-        }
-
-
-        public IEnumerable<StoredProcedureMapping> StoredProcedures
-        {
-            get { return storedProcedures; }
+            AddOrReplaceMapping(mapping, MappingType.Filter, x => x.Name == mapping.Name);
         }
 
         public void AddProperty(PropertyMapping property)
         {
-            if (properties.Exists(x => x.Name == property.Name))
+            if (Properties.Any(x => x.Name == property.Name))
                 throw new InvalidOperationException("Tried to add property '" + property.Name + "' when already added.");
-
-            properties.Add(property);
+            AddMapping(property, MappingType.Property);
         }
 
         public void AddOrReplaceProperty(PropertyMapping mapping)
         {
-            properties.RemoveAll(x => x.Name == mapping.Name);
-            properties.Add(mapping);
+            AddOrReplaceMapping(mapping, MappingType.Property, x => x.Name == mapping.Name);
         }
 
         public void AddCollection(Collections.CollectionMapping collection)
         {
-            if (collections.Exists(x => x.Name == collection.Name))
+            if (Collections.Any(x => x.Name == collection.Name))
                 throw new InvalidOperationException("Tried to add collection '" + collection.Name + "' when already added.");
-
-            collections.Add(collection);
+            AddMapping(collection, MappingType.Collection);
         }
 
         public void AddOrReplaceCollection(Collections.CollectionMapping mapping)
         {
-            collections.RemoveAll(x => x.Name == mapping.Name);
-            collections.Add(mapping);
+            AddOrReplaceMapping(mapping, MappingType.Collection, x => x.Name == mapping.Name);
         }
 
         public void AddReference(ManyToOneMapping manyToOne)
         {
-            if (references.Exists(x => x.Name == manyToOne.Name))
+            if (References.Any(x => x.Name == manyToOne.Name))
                 throw new InvalidOperationException("Tried to add many-to-one '" + manyToOne.Name + "' when already added.");
-
-            references.Add(manyToOne);
+            AddMapping(manyToOne, MappingType.ManyToOne);
         }
 
         public void AddOrReplaceReference(ManyToOneMapping manyToOne)
         {
-            references.RemoveAll(x => x.Name == manyToOne.Name);
-            references.Add(manyToOne);
+            AddOrReplaceMapping(manyToOne, MappingType.ManyToOne, x => x.Name == manyToOne.Name);
         }
 
         public void AddComponent(IComponentMapping componentMapping)
         {
-            if (components.Exists(x => x.Name == componentMapping.Name))
+            if (Components.Any(x => x.Name == componentMapping.Name))
                 throw new InvalidOperationException("Tried to add component '" + componentMapping.Name + "' when already added.");
-
-            components.Add(componentMapping);
+            AddMapping(componentMapping, MappingType.IComponent);
         }
 
         public void AddOrReplaceComponent(IComponentMapping componentMapping)
         {
-            components.RemoveAll(x => x.Name == componentMapping.Name);
-            components.Add(componentMapping);
+            AddOrReplaceMapping(componentMapping, MappingType.IComponent, x => x.Name == componentMapping.Name);
         }
 
         public void AddOneToOne(OneToOneMapping mapping)
         {
-            if (oneToOnes.Exists(x => x.Name == mapping.Name))
+            if (OneToOnes.Any(x => x.Name == mapping.Name))
                 throw new InvalidOperationException("Tried to add one-to-one '" + mapping.Name + "' when already added.");
-
-            oneToOnes.Add(mapping);
+            AddMapping(mapping, MappingType.OneToOne);
         }
 
         public void AddOrReplaceOneToOne(OneToOneMapping mapping)
         {
-            oneToOnes.RemoveAll(x => x.Name == mapping.Name);
-            oneToOnes.Add(mapping);
+            AddOrReplaceMapping(mapping, MappingType.OneToOne, x => x.Name == mapping.Name);
         }
 
         public void AddAny(AnyMapping mapping)
         {
-            if (anys.Exists(x => x.Name == mapping.Name))
+            if (Anys.Any(x => x.Name == mapping.Name))
                 throw new InvalidOperationException("Tried to add any '" + mapping.Name + "' when already added.");
-
-            anys.Add(mapping);
+            AddMapping(mapping, MappingType.Any);
         }
 
         public void AddOrReplaceAny(AnyMapping mapping)
         {
-            anys.RemoveAll(x => x.Name == mapping.Name);
-            anys.Add(mapping);
+            AddOrReplaceMapping(mapping, MappingType.Any, x => x.Name == mapping.Name);
         }
 
         public void AddJoin(JoinMapping mapping)
         {
-            if (joins.Exists(x => x.TableName == mapping.TableName))
+            if (Joins.Any(x => x.TableName == mapping.TableName))
                 throw new InvalidOperationException("Tried to add join to table '" + mapping.TableName + "' when already added.");
-
-            joins.Add(mapping);
+            AddMapping(mapping, MappingType.Join);
         }
 
         public void AddFilter(FilterMapping mapping)
         {
-            if (filters.Exists(x => x.Name == mapping.Name))
+            if (Filters.Any(x => x.Name == mapping.Name))
                 throw new InvalidOperationException("Tried to add filter with name '" + mapping.Name + "' when already added.");
-
-            filters.Add(mapping);
+            AddMapping(mapping, MappingType.Filter);
         }
 
         public virtual void AcceptVisitor(IMappingModelVisitor visitor)
         {
-            foreach (var collection in Collections)
-                visitor.Visit(collection);
-
-            foreach (var property in Properties)
-                visitor.Visit(property);
-
-            foreach (var reference in References)
-                visitor.Visit(reference);
-
-            foreach (var component in Components)
-                visitor.Visit(component);
-
-            foreach (var oneToOne in oneToOnes)
-                visitor.Visit(oneToOne);
-
-            foreach (var any in anys)
-                visitor.Visit(any);
-
-            foreach (var join in joins)
-                visitor.Visit(join);
-
-            foreach (var filter in filters)
-                visitor.Visit(filter);
-
-            foreach (var storedProcedure in storedProcedures)
-                visitor.Visit(storedProcedure);
+            foreach(var mapping in orderedMappings)
+                switch (mapping.Item1) {
+                    case MappingType.Property:
+                        visitor.Visit((PropertyMapping)mapping.Item2);
+                        break;
+                    case MappingType.Collection:
+                        visitor.Visit((Collections.CollectionMapping)mapping.Item2);
+                        break;
+                    case MappingType.ManyToOne:
+                        visitor.Visit((ManyToOneMapping)mapping.Item2);
+                        break;
+                    case MappingType.IComponent:
+                        visitor.Visit((IComponentMapping)mapping.Item2);
+                        break;
+                    case MappingType.OneToOne:
+                        visitor.Visit((OneToOneMapping)mapping.Item2);
+                        break;
+                    case MappingType.Any:
+                        visitor.Visit((AnyMapping)mapping.Item2);
+                        break;
+                    case MappingType.Join:
+                        visitor.Visit((JoinMapping)mapping.Item2);
+                        break;
+                    case MappingType.Filter:
+                        visitor.Visit((FilterMapping)mapping.Item2);
+                        break;
+                    case MappingType.StoredProcedure:
+                        visitor.Visit((StoredProcedureMapping)mapping.Item2);
+                        break;
+                    default:
+                        throw new Exception("Internal Error: unsupported mapping type " + mapping.Item1);
+                }
         }
 
         public bool IsSpecified(string property)
@@ -225,22 +185,14 @@ namespace FluentNHibernate.MappingModel
 
         public void AddStoredProcedure(StoredProcedureMapping mapping)
         {
-            storedProcedures.Add(mapping);
+            AddMapping(mapping, MappingType.StoredProcedure);
         }
 
         public bool Equals(MappedMembers other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return other.properties.ContentEquals(properties) &&
-                other.collections.ContentEquals(collections) &&
-                other.references.ContentEquals(references) &&
-                other.components.ContentEquals(components) &&
-                other.oneToOnes.ContentEquals(oneToOnes) &&
-                other.anys.ContentEquals(anys) &&
-                other.joins.ContentEquals(joins) &&
-                other.filters.ContentEquals(filters) &&
-                other.storedProcedures.ContentEquals(storedProcedures);
+            return other.orderedMappings.ContentEquals(orderedMappings);
         }
 
         public override bool Equals(object obj)
@@ -251,22 +203,23 @@ namespace FluentNHibernate.MappingModel
             return Equals((MappedMembers)obj);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int result = (properties != null ? properties.GetHashCode() : 0);
-                result = (result * 397) ^ (collections != null ? collections.GetHashCode() : 0);
-                result = (result * 397) ^ (references != null ? references.GetHashCode() : 0);
-                result = (result * 397) ^ (components != null ? components.GetHashCode() : 0);
-                result = (result * 397) ^ (oneToOnes != null ? oneToOnes.GetHashCode() : 0);
-                result = (result * 397) ^ (anys != null ? anys.GetHashCode() : 0);
-                result = (result * 397) ^ (joins != null ? joins.GetHashCode() : 0);
-                result = (result * 397) ^ (filters != null ? filters.GetHashCode() : 0);
-                result = (result * 397) ^ (storedProcedures != null ? storedProcedures.GetHashCode() : 0);
-                return result;
-            }
+        public override int GetHashCode() {
+            return orderedMappings.GetHashCode();
+        }
+
+        private void AddMapping<TMapping>(TMapping mapping, MappingType mappingType) where TMapping : IMapping {
+            orderedMappings.Add(Tuple.Create(mappingType, (IMapping)mapping));
+        }
+
+        private void AddOrReplaceMapping<TMapping>(TMapping mapping, MappingType mappingType, Predicate<TMapping> matchPredicate) {
+            var newMapping = Tuple.Create(mappingType, (IMapping)mapping);            
+            var index = orderedMappings.FindIndex(x => x.Item1 == mappingType && matchPredicate((TMapping)x.Item2));
+            if (index >= 0)
+                orderedMappings[index] = newMapping;
+            else
+                orderedMappings.Add(newMapping);
         }
 
     }
 }
+

--- a/src/FluentNHibernate/Utils/ObservableDictionary.cs
+++ b/src/FluentNHibernate/Utils/ObservableDictionary.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace FluentNHibernate.Utils {
+
+    public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue>, INotifyCollectionChanged, INotifyPropertyChanged {
+        private const string CountString = "Count";
+        private const string IndexerName = "Item[]";
+        private const string KeysName = "Keys";
+        private const string ValuesName = "Values";
+
+        private IDictionary<TKey, TValue> _dictionary;
+
+        protected IDictionary<TKey, TValue> Dictionary {
+            get { return _dictionary; }
+        }
+
+        #region Constructors
+
+        public ObservableDictionary() {
+            _dictionary = new Dictionary<TKey, TValue>();
+        }
+
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary) {
+            _dictionary = new Dictionary<TKey, TValue>(dictionary);
+        }
+
+        public ObservableDictionary(IEqualityComparer<TKey> comparer) {
+            _dictionary = new Dictionary<TKey, TValue>(comparer);
+        }
+
+        public ObservableDictionary(int capacity) {
+            _dictionary = new Dictionary<TKey, TValue>(capacity);
+        }
+
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) {
+            _dictionary = new Dictionary<TKey, TValue>(dictionary, comparer);
+        }
+
+        public ObservableDictionary(int capacity, IEqualityComparer<TKey> comparer) {
+            _dictionary = new Dictionary<TKey, TValue>(capacity, comparer);
+        }
+
+        #endregion
+
+        #region IDictionary<TKey,TValue> Members
+
+        public void Add(TKey key, TValue value) {
+            Insert(key, value, true);
+        }
+
+        public bool ContainsKey(TKey key) {
+            return Dictionary.ContainsKey(key);
+        }
+
+        public ICollection<TKey> Keys {
+            get { return Dictionary.Keys; }
+        }
+
+        public bool Remove(TKey key) {
+            if (key == null) throw new ArgumentNullException("key");
+
+            TValue value;
+            Dictionary.TryGetValue(key, out value);
+            var removed = Dictionary.Remove(key);
+            if (removed)
+                //OnCollectionChanged(NotifyCollectionChangedAction.Remove, new KeyValuePair<TKey, TValue>(key, value));
+                OnCollectionChanged();
+            return removed;
+        }
+
+        public bool TryGetValue(TKey key, out TValue value) {
+            return Dictionary.TryGetValue(key, out value);
+        }
+
+        public ICollection<TValue> Values {
+            get { return Dictionary.Values; }
+        }
+
+        public TValue this[TKey key] {
+            get {
+                TValue value;
+                return TryGetValue(key, out value) ? value : default(TValue);
+            }
+            set { Insert(key, value, false); }
+        }
+
+        #endregion
+
+        #region ICollection<KeyValuePair<TKey,TValue>> Members
+
+        public void Add(KeyValuePair<TKey, TValue> item) {
+            Insert(item.Key, item.Value, true);
+        }
+
+        public void Clear() {
+            if (Dictionary.Count > 0) {
+                Dictionary.Clear();
+                OnCollectionChanged();
+            }
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item) {
+            return Dictionary.Contains(item);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) {
+            Dictionary.CopyTo(array, arrayIndex);
+        }
+
+        public int Count {
+            get { return Dictionary.Count; }
+        }
+
+        public bool IsReadOnly {
+            get { return Dictionary.IsReadOnly; }
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item) {
+            return Remove(item.Key);
+        }
+
+
+        #endregion
+
+        #region IEnumerable<KeyValuePair<TKey,TValue>> Members
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() {
+            return Dictionary.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return ((IEnumerable)Dictionary).GetEnumerator();
+        }
+
+        #endregion
+
+        #region INotifyCollectionChanged Members
+
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        #endregion
+
+        #region INotifyPropertyChanged Members
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        #endregion
+
+        public void AddRange(IDictionary<TKey, TValue> items) {
+            if (items == null) throw new ArgumentNullException("items");
+
+            if (items.Count > 0) {
+                if (Dictionary.Count > 0) {
+                    if (items.Keys.Any((k) => Dictionary.ContainsKey(k)))
+                        throw new ArgumentException("An item with the same key has already been added.");
+                    else
+                        foreach (var item in items) Dictionary.Add(item);
+                } else
+                    _dictionary = new Dictionary<TKey, TValue>(items);
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Add, items.ToArray());
+            }
+        }
+
+        private void Insert(TKey key, TValue value, bool add) {
+            if (key == null) throw new ArgumentNullException("key");
+
+            TValue item;
+            if (Dictionary.TryGetValue(key, out item)) {
+                if (add) throw new ArgumentException("An item with the same key has already been added.");
+                if (Equals(item, value)) return;
+                Dictionary[key] = value;
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Replace, new KeyValuePair<TKey, TValue>(key, value), new KeyValuePair<TKey, TValue>(key, item));
+                OnPropertyChanged(key.ToString());
+            } else {
+                Dictionary[key] = value;
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value));
+                OnPropertyChanged(key.ToString());
+            }
+        }
+
+        private void OnPropertyChanged() {
+            OnPropertyChanged(CountString);
+            OnPropertyChanged(IndexerName);
+            OnPropertyChanged(KeysName);
+            OnPropertyChanged(ValuesName);
+        }
+
+        protected virtual void OnPropertyChanged(string propertyName) {
+            if (PropertyChanged != null) PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private void OnCollectionChanged() {
+            OnPropertyChanged();
+            if (CollectionChanged != null) CollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> changedItem) {
+            OnPropertyChanged();
+            if (CollectionChanged != null) CollectionChanged(this, new NotifyCollectionChangedEventArgs(action, changedItem, 0));
+        }
+
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> newItem, KeyValuePair<TKey, TValue> oldItem) {
+            OnPropertyChanged();
+            if (CollectionChanged != null) CollectionChanged(this, new NotifyCollectionChangedEventArgs(action, newItem, oldItem, 0));
+        }
+
+        private void OnCollectionChanged(NotifyCollectionChangedAction action, IList newItems) {
+            OnPropertyChanged();
+            if (CollectionChanged != null) CollectionChanged(this, new NotifyCollectionChangedEventArgs(action, newItems, 0));
+        }
+
+    }
+}


### PR DESCRIPTION
This is a long-awaited feature for many users. Prior pull request had unit test errors. The code has been re-done, all tests pass and has been QA'd on my end. 

All mappings are DB-generated in the order they were declared, which is useful for cosmetic purposes as well as some legacy compatibility use-cases. 